### PR TITLE
feat(session): warn user when session expires and resets

### DIFF
--- a/src/claude-cli.ts
+++ b/src/claude-cli.ts
@@ -4,6 +4,7 @@ export interface ClaudeResult {
   text: string;
   sessionId: string;
   isError: boolean;
+  sessionReset?: boolean;
 }
 
 export function parseClaudeJsonOutput(raw: string): ClaudeResult {

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -197,6 +197,10 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
         resolved.isThread ? { worktree: true } : undefined,
       );
 
+      if (result.sessionReset) {
+        await replyChannel.send('⚠️ Previous session expired — starting fresh.');
+      }
+
       const chunks = chunkMessage(result.text, 2000);
       for (const chunk of chunks) {
         await replyChannel.send(chunk);

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -119,7 +119,7 @@ export function createSessionManager(defaults: {
             session.lastActivity = Date.now();
             resetIdleTimer(session);
             persistSessions();
-            item.resolve(result);
+            item.resolve({ ...result, sessionReset: true });
           } catch (retryErr) {
             item.reject(retryErr instanceof Error ? retryErr : new Error(String(retryErr)));
           }

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -118,6 +118,7 @@ describe('SessionManager', () => {
 
     const result = await manager.send('project-a', '/tmp/a', 'Try again');
     expect(result.text).toBe('Recovered');
+    expect(result.sessionReset).toBe(true);
     expect(manager.getSession('project-a')?.sessionId).toBe('sid-2');
   });
 


### PR DESCRIPTION
## Summary
- Adds `sessionReset` flag to `ClaudeResult` interface to signal when a session was silently restarted
- Posts a warning message in Discord when `--resume` fails and a fresh session is created
- Adds test coverage for the `sessionReset` flag on retry path

Closes #26
Partially addresses #22 (detection and warning; message replay is future work)

## Test plan
- [x] All 65 existing tests pass
- [x] `sessionReset` flag is set to `true` when retry creates a new session
- [ ] Manual: trigger session expiry in Discord and verify warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)