### PR TITLE
feat(cli): add configurable process timeout to prevent stalls

### DIFF
--- a/src/claude-cli.ts
+++ b/src/claude-cli.ts
@@ -47,11 +47,17 @@ export function friendlyError(stderr: string): string {
   return `Claude error: ${stderr.slice(0, 500)}`;
 }
 
+export interface RunClaudeOptions {
+  /** Kill the subprocess after this many milliseconds. No timeout if omitted. */
+  timeoutMs?: number;
+}
+
 export function runClaude(
   cwd: string,
   baseArgs: string[],
   prompt: string,
   sessionId: string | undefined,
+  options?: RunClaudeOptions,
 ): Promise<ClaudeResult> {
   return new Promise((resolve, reject) => {
     const args = buildClaudeArgs(baseArgs, prompt, sessionId);
@@ -62,6 +68,15 @@ export function runClaude(
 
     let stdout = '';
     let stderr = '';
+    let timedOut = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    if (options?.timeoutMs) {
+      timer = setTimeout(() => {
+        timedOut = true;
+        proc.kill('SIGTERM');
+      }, options.timeoutMs);
+    }
 
     proc.stdout.on('data', (chunk: Buffer) => {
       stdout += chunk.toString();
@@ -72,6 +87,12 @@ export function runClaude(
     });
 
     proc.on('close', (code) => {
+      if (timer) clearTimeout(timer);
+      if (timedOut) {
+        const seconds = Math.round((options?.timeoutMs ?? 0) / 1000);
+        reject(new Error(`Claude process timed out after ${seconds}s — the request may be too complex or Claude may be stuck.`));
+        return;
+      }
       if (code !== 0) {
         reject(new Error(friendlyError(stderr)));
         return;
@@ -85,6 +106,7 @@ export function runClaude(
     });
 
     proc.on('error', (err) => {
+      if (timer) clearTimeout(timer);
       reject(new Error(`Failed to spawn claude: ${err.message}`));
     });
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ export interface GatewayDefaults {
   maxConcurrentSessions: number;
   sessionTtlMs: number;
   maxPersistedSessions: number;
+  processTimeoutMs: number;
   claudeArgs: string[];
 }
 
@@ -56,6 +57,7 @@ export function loadConfig(raw: unknown): GatewayConfig {
       maxConcurrentSessions: typeof defaults.maxConcurrentSessions === 'number' ? defaults.maxConcurrentSessions : 4,
       sessionTtlMs: typeof defaults.sessionTtlMs === 'number' ? defaults.sessionTtlMs : 7 * 24 * 60 * 60 * 1000,
       maxPersistedSessions: typeof defaults.maxPersistedSessions === 'number' ? defaults.maxPersistedSessions : 50,
+      processTimeoutMs: typeof defaults.processTimeoutMs === 'number' ? defaults.processTimeoutMs : 300000,
       claudeArgs: Array.isArray(defaults.claudeArgs) ? (defaults.claudeArgs as string[]) : ['--permission-mode', 'acceptEdits', '--output-format', 'json'],
     },
     projects: validated,

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -39,11 +39,13 @@ export function createSessionManager(defaults: {
   maxConcurrentSessions: number;
   sessionTtlMs?: number;
   maxPersistedSessions?: number;
+  processTimeoutMs?: number;
   claudeArgs: string[];
 }, store?: SessionStore): SessionManager {
   const sessions = new Map<string, InternalSession>();
   const sessionTtlMs = defaults.sessionTtlMs ?? 7 * 24 * 60 * 60 * 1000;
   const maxPersistedSessions = defaults.maxPersistedSessions ?? 50;
+  const processTimeoutMs = defaults.processTimeoutMs;
 
   let activeProcesses = 0;
   const waiters: Array<() => void> = [];
@@ -138,6 +140,7 @@ export function createSessionManager(defaults: {
           defaults.claudeArgs,
           item.prompt,
           session.sessionId,
+          processTimeoutMs ? { timeoutMs: processTimeoutMs } : undefined,
         );
         const sessionChanged = !!(
           session.sessionId &&
@@ -157,7 +160,7 @@ export function createSessionManager(defaults: {
         if (session.sessionId) {
           session.sessionId = undefined;
           try {
-            const result = await runClaude(session.cwd, defaults.claudeArgs, item.prompt, undefined);
+            const result = await runClaude(session.cwd, defaults.claudeArgs, item.prompt, undefined, processTimeoutMs ? { timeoutMs: processTimeoutMs } : undefined);
             session.sessionId = result.sessionId || undefined;
             session.lastActivity = Date.now();
             resetIdleTimer(session);

--- a/tests/claude-cli.test.ts
+++ b/tests/claude-cli.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect, vi } from 'vitest';
-import { parseClaudeJsonOutput, buildClaudeArgs, friendlyError } from '../src/claude-cli.js';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { parseClaudeJsonOutput, buildClaudeArgs, friendlyError, runClaude } from '../src/claude-cli.js';
+import * as child_process from 'node:child_process';
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof child_process>('node:child_process');
+  return { ...actual, spawn: actual.spawn };
+});
 
 describe('parseClaudeJsonOutput', () => {
   it('extracts result text and session_id from JSON output', () => {
@@ -88,5 +94,106 @@ describe('friendlyError', () => {
     const msg = friendlyError('something unexpected happened');
     expect(msg).toContain('Claude error:');
     expect(msg).toContain('something unexpected happened');
+  });
+});
+
+describe('runClaude timeout', () => {
+  it('rejects with a timeout error when process exceeds timeoutMs', async () => {
+    const { EventEmitter } = await import('node:events');
+    const { Readable } = await import('node:stream');
+
+    const mockProc = new EventEmitter() as any;
+    mockProc.stdout = new Readable({ read() {} });
+    mockProc.stderr = new Readable({ read() {} });
+    mockProc.kill = vi.fn(() => {
+      setTimeout(() => mockProc.emit('close', null), 10);
+    });
+
+    const spawnSpy = vi.spyOn(child_process, 'spawn').mockReturnValueOnce(mockProc as any);
+
+    const result = runClaude('/tmp', [], 'hello', undefined, { timeoutMs: 100 });
+    await expect(result).rejects.toThrow(/timed out/i);
+
+    spawnSpy.mockRestore();
+  });
+
+  it('completes normally when process finishes before timeout', async () => {
+    // Spawn a quick echo command — mock spawn to return valid JSON
+    const { EventEmitter } = await import('node:events');
+    const { Readable } = await import('node:stream');
+
+    const jsonOutput = JSON.stringify({
+      result: 'done',
+      session_id: 'sess-1',
+      is_error: false,
+    });
+
+    const mockProc = new EventEmitter() as any;
+    mockProc.stdout = Readable.from([Buffer.from(jsonOutput)]);
+    mockProc.stderr = Readable.from([]);
+    mockProc.kill = vi.fn();
+
+    const spawnSpy = vi.spyOn(child_process, 'spawn').mockReturnValueOnce(mockProc as any);
+
+    const promise = runClaude('/tmp', [], 'hello', undefined, { timeoutMs: 5000 });
+
+    // Simulate process close after stdout is consumed
+    setTimeout(() => mockProc.emit('close', 0), 50);
+
+    const result = await promise;
+    expect(result.text).toBe('done');
+    expect(result.sessionId).toBe('sess-1');
+    expect(mockProc.kill).not.toHaveBeenCalled();
+
+    spawnSpy.mockRestore();
+  });
+
+  it('kills the subprocess when timeout fires', async () => {
+    const { EventEmitter } = await import('node:events');
+    const { Readable } = await import('node:stream');
+
+    const mockProc = new EventEmitter() as any;
+    // stdout that never ends
+    mockProc.stdout = new Readable({ read() {} });
+    mockProc.stderr = new Readable({ read() {} });
+    mockProc.kill = vi.fn(() => {
+      // Simulate the process exiting after being killed
+      setTimeout(() => mockProc.emit('close', null), 10);
+    });
+
+    const spawnSpy = vi.spyOn(child_process, 'spawn').mockReturnValueOnce(mockProc as any);
+
+    const promise = runClaude('/tmp', [], 'hello', undefined, { timeoutMs: 100 });
+    await expect(promise).rejects.toThrow(/timed out/i);
+    expect(mockProc.kill).toHaveBeenCalledWith('SIGTERM');
+
+    spawnSpy.mockRestore();
+  });
+
+  it('uses no timeout by default (timeoutMs not provided)', async () => {
+    const { EventEmitter } = await import('node:events');
+    const { Readable } = await import('node:stream');
+
+    const jsonOutput = JSON.stringify({
+      result: 'ok',
+      session_id: 'sess-2',
+      is_error: false,
+    });
+
+    const mockProc = new EventEmitter() as any;
+    mockProc.stdout = Readable.from([Buffer.from(jsonOutput)]);
+    mockProc.stderr = Readable.from([]);
+    mockProc.kill = vi.fn();
+
+    const spawnSpy = vi.spyOn(child_process, 'spawn').mockReturnValueOnce(mockProc as any);
+
+    const promise = runClaude('/tmp', [], 'hello', undefined);
+    setTimeout(() => mockProc.emit('close', 0), 50);
+
+    const result = await promise;
+    expect(result.text).toBe('ok');
+    expect(mockProc.kill).not.toHaveBeenCalled();
+
+    spawnSpy.mockRestore();
   });
 });

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -252,7 +252,7 @@ describe('SessionManager', () => {
       const m = createSessionManager(defaults, store);
 
       await m.send('proj-a', '/tmp/a', 'Continue');
-      expect(mockRun).toHaveBeenCalledWith('/tmp/a', defaults.claudeArgs, 'Continue', 'old-sid');
+      expect(mockRun).toHaveBeenCalledWith('/tmp/a', defaults.claudeArgs, 'Continue', 'old-sid', undefined);
       m.shutdown();
     });
 
@@ -291,7 +291,7 @@ describe('SessionManager', () => {
       mockRun.mockResolvedValueOnce({ text: 'Resumed', sessionId: 'sid-1', isError: false });
       const result = await m.send('proj-a', '/tmp/a', 'Back again');
       expect(result.text).toBe('Resumed');
-      expect(mockRun).toHaveBeenLastCalledWith('/tmp/a', defaults.claudeArgs, 'Back again', 'sid-1');
+      expect(mockRun).toHaveBeenLastCalledWith('/tmp/a', defaults.claudeArgs, 'Back again', 'sid-1', undefined);
       m.shutdown();
     });
   });
@@ -312,6 +312,7 @@ describe('SessionManager', () => {
         '/tmp/a/.worktrees/thread-1',
         defaults.claudeArgs,
         'Hello',
+        undefined,
         undefined,
       );
     });
@@ -337,7 +338,7 @@ describe('SessionManager', () => {
       await manager.send('project-a', '/tmp/a', 'Hello');
 
       expect(mockCreate).not.toHaveBeenCalled();
-      expect(mockRun).toHaveBeenCalledWith('/tmp/a', defaults.claudeArgs, 'Hello', undefined);
+      expect(mockRun).toHaveBeenCalledWith('/tmp/a', defaults.claudeArgs, 'Hello', undefined, undefined);
     });
 
     it('removes worktree on clearSession', async () => {


### PR DESCRIPTION
## Summary
- Adds `timeoutMs` option to `runClaude` that kills the Claude subprocess with SIGTERM if it exceeds the configured duration
- Adds `processTimeoutMs` to `GatewayDefaults` (default: 5 minutes), configurable per gateway
- SessionManager passes the timeout through to both primary and retry `runClaude` calls
- Returns a friendly timeout error to Discord users when triggered

## Context
Addresses the agent dispatch stall issue where the typing indicator runs indefinitely when a Claude subprocess hangs (e.g., when Claude Code internally dispatches a subagent that stalls). The gateway previously had no ability to detect or recover from this — it would keep sending typing indicators every 7 seconds forever.

## Test Plan
- [x] Timeout rejection: mock subprocess that never completes is killed and promise rejects with `/timed out/i`
- [x] Normal completion: subprocess finishing before timeout resolves normally, `kill` not called
- [x] Subprocess kill: verifies `SIGTERM` is sent when timeout fires
- [x] Default behavior: no timeout when `timeoutMs` not provided
- [x] All 113 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)