### PR TITLE
feat: add structured logger and mpg logs CLI subcommand

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import {
   resolveProfileDir,
   parseFlags,
 } from './resolve-home.js';
+import { createLogger, parseLogEntry, filterLogEntries, type LogLevel, isValidLogLevel } from './logger.js';
 
 const args = process.argv.slice(2);
 const command = args[0] ?? 'start';
@@ -35,6 +36,8 @@ async function main() {
       return runInit(flags.profileFlag);
     case 'status':
       return status();
+    case 'logs':
+      return logs();
     case 'help':
     case '--help':
     case '-h':
@@ -59,14 +62,17 @@ Commands:
   start     Start the gateway (default)
   init      Interactive setup wizard
   status    Show session status
+  logs      Filter structured log output (reads stdin)
   help      Show this message
 
 Options:
-  --profile <name>  Use a named profile (default: "default")
-  --config <path>   Use a specific config.json path
-  --migrate         Copy CWD config files into ~/.mpg/profiles/default/
-  -v, --version     Show version
-  -h, --help        Show this message
+  --profile <name>   Use a named profile (default: "default")
+  --config <path>    Use a specific config.json path
+  --migrate          Copy CWD config files into ~/.mpg/profiles/default/
+  --project <name>   (logs) Filter by project name
+  --level <level>    (logs) Filter by minimum log level (debug|info|warn|error)
+  -v, --version      Show version
+  -h, --help         Show this message
 
 Environment:
   MPG_HOME          Override config home (default: ~/.mpg)
@@ -103,6 +109,8 @@ function start() {
   const rawConfig = JSON.parse(readFileSync(configPath, 'utf-8'));
   const config = loadConfig(rawConfig);
 
+  const log = createLogger(config.defaults.logLevel);
+
   const projectCount = Object.keys(config.projects).length;
   if (projectCount === 0) {
     console.error('No projects configured in config.json');
@@ -111,7 +119,7 @@ function start() {
 
   runHealthChecks(config);
 
-  console.log(`Loaded ${projectCount} project(s) from ${configPath}`);
+  log.info(`Loaded ${projectCount} project(s) from ${configPath}`);
 
   const router = createRouter(config);
   const sessionsPath = resolveSessionsPath(configPath);
@@ -141,7 +149,7 @@ function start() {
   let healthServer: HealthServer | undefined;
 
   function shutdown() {
-    console.log('Shutting down...');
+    log.info('Shutting down...');
     if (healthServer) {
       healthServer.close().catch(() => {});
     }
@@ -159,12 +167,12 @@ function start() {
         try {
           healthServer = await createHealthServer(config.defaults.httpPort, sessionManager, bot);
         } catch (err) {
-          console.warn(`Health server failed to start on port ${config.defaults.httpPort}:`, err);
+          log.warn(`Health server failed to start on port ${config.defaults.httpPort}: ${err}`);
         }
       }
     })
     .catch((err) => {
-      console.error('Failed to start bot:', err);
+      log.error(`Failed to start bot: ${err}`);
       process.exit(1);
     });
 }
@@ -266,6 +274,60 @@ function migrate() {
   }
   console.log(`\nProfile directory: ${profileDir}`);
   console.log('You can now run `mpg start` from any directory.');
+}
+
+function logs() {
+  const levelFlag = flags.level;
+  const projectFlag = flags.project;
+
+  if (levelFlag && !isValidLogLevel(levelFlag)) {
+    console.error(`Invalid log level: ${levelFlag}. Must be one of: debug, info, warn, error`);
+    process.exit(1);
+  }
+
+  const minLevel = levelFlag as LogLevel | undefined;
+
+  let buffer = '';
+  process.stdin.setEncoding('utf-8');
+  process.stdin.on('data', (chunk: string) => {
+    buffer += chunk;
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      const entry = parseLogEntry(line);
+      if (!entry) {
+        // Pass through non-JSON lines as-is
+        process.stdout.write(line + '\n');
+        continue;
+      }
+      const [filtered] = filterLogEntries([entry], { project: projectFlag, level: minLevel });
+      if (filtered) {
+        const ts = entry.timestamp.replace('T', ' ').replace('Z', '');
+        const proj = entry.project ? ` [${entry.project}]` : '';
+        const sess = entry.session ? ` (${entry.session.slice(0, 8)})` : '';
+        process.stdout.write(`${ts} ${entry.level.toUpperCase().padEnd(5)}${proj}${sess} ${entry.message}\n`);
+      }
+    }
+  });
+
+  process.stdin.on('end', () => {
+    if (buffer.trim()) {
+      const entry = parseLogEntry(buffer);
+      if (!entry) {
+        process.stdout.write(buffer + '\n');
+      } else {
+        const [filtered] = filterLogEntries([entry], { project: projectFlag, level: minLevel });
+        if (filtered) {
+          const ts = entry.timestamp.replace('T', ' ').replace('Z', '');
+          const proj = entry.project ? ` [${entry.project}]` : '';
+          const sess = entry.session ? ` (${entry.session.slice(0, 8)})` : '';
+          process.stdout.write(`${ts} ${entry.level.toUpperCase().padEnd(5)}${proj}${sess} ${entry.message}\n`);
+        }
+      }
+    }
+  });
 }
 
 main().catch((err) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import { resolvePreset } from './persona-presets.js';
+import { isValidLogLevel, type LogLevel } from './logger.js';
 
 export interface AgentConfig {
   role: string;
@@ -42,6 +43,7 @@ export interface GatewayDefaults {
   maxTurnsPerAgent: number;
   agentTimeoutMs: number;
   httpPort: number | false;
+  logLevel: LogLevel;
 }
 
 export interface GatewayConfig {
@@ -146,6 +148,7 @@ export function loadConfig(raw: unknown): GatewayConfig {
       maxTurnsPerAgent: typeof defaults.maxTurnsPerAgent === 'number' ? defaults.maxTurnsPerAgent : 5,
       agentTimeoutMs: typeof defaults.agentTimeoutMs === 'number' ? defaults.agentTimeoutMs : 3 * 60 * 1000,
       httpPort: defaults.httpPort === false ? false : (typeof defaults.httpPort === 'number' ? defaults.httpPort : 3100),
+      logLevel: isValidLogLevel(defaults.logLevel) ? defaults.logLevel : 'info',
     },
     projects: validated,
   };

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,95 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const LEVEL_ORDER: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+export interface LogEntry {
+  timestamp: string;
+  level: LogLevel;
+  message: string;
+  project?: string;
+  session?: string;
+}
+
+export interface Logger {
+  debug(message: string, ctx?: { project?: string; session?: string }): void;
+  info(message: string, ctx?: { project?: string; session?: string }): void;
+  warn(message: string, ctx?: { project?: string; session?: string }): void;
+  error(message: string, ctx?: { project?: string; session?: string }): void;
+}
+
+export function shouldLog(entryLevel: LogLevel, minLevel: LogLevel): boolean {
+  return LEVEL_ORDER[entryLevel] >= LEVEL_ORDER[minLevel];
+}
+
+export function formatLogEntry(entry: LogEntry): string {
+  return JSON.stringify(entry);
+}
+
+export function parseLogEntry(line: string): LogEntry | null {
+  try {
+    const parsed = JSON.parse(line);
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      typeof parsed.timestamp === 'string' &&
+      typeof parsed.level === 'string' &&
+      typeof parsed.message === 'string' &&
+      parsed.level in LEVEL_ORDER
+    ) {
+      return parsed as LogEntry;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function filterLogEntries(
+  entries: LogEntry[],
+  opts?: { project?: string; level?: LogLevel },
+): LogEntry[] {
+  return entries.filter((entry) => {
+    if (opts?.level && !shouldLog(entry.level, opts.level)) {
+      return false;
+    }
+    if (opts?.project && entry.project !== opts.project) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function createLogger(
+  minLevel: LogLevel = 'info',
+  writer: (line: string) => void = (line) => process.stderr.write(line + '\n'),
+): Logger {
+  function log(level: LogLevel, message: string, ctx?: { project?: string; session?: string }): void {
+    if (!shouldLog(level, minLevel)) return;
+
+    const entry: LogEntry = {
+      timestamp: new Date().toISOString(),
+      level,
+      message,
+      ...(ctx?.project && { project: ctx.project }),
+      ...(ctx?.session && { session: ctx.session }),
+    };
+
+    writer(formatLogEntry(entry));
+  }
+
+  return {
+    debug: (message, ctx) => log('debug', message, ctx),
+    info: (message, ctx) => log('info', message, ctx),
+    warn: (message, ctx) => log('warn', message, ctx),
+    error: (message, ctx) => log('error', message, ctx),
+  };
+}
+
+export function isValidLogLevel(value: unknown): value is LogLevel {
+  return typeof value === 'string' && value in LEVEL_ORDER;
+}

--- a/src/resolve-home.ts
+++ b/src/resolve-home.ts
@@ -108,8 +108,10 @@ export function parseFlags(argv: string[]): {
   configFlag?: string;
   profileFlag?: string;
   migrate?: boolean;
+  project?: string;
+  level?: string;
 } {
-  const result: { configFlag?: string; profileFlag?: string; migrate?: boolean } = {};
+  const result: { configFlag?: string; profileFlag?: string; migrate?: boolean; project?: string; level?: string } = {};
 
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === '--config' && i + 1 < argv.length) {
@@ -117,6 +119,12 @@ export function parseFlags(argv: string[]): {
       i++;
     } else if (argv[i] === '--profile' && i + 1 < argv.length) {
       result.profileFlag = argv[i + 1];
+      i++;
+    } else if (argv[i] === '--project' && i + 1 < argv.length) {
+      result.project = argv[i + 1];
+      i++;
+    } else if (argv[i] === '--level' && i + 1 < argv.length) {
+      result.level = argv[i + 1];
       i++;
     } else if (argv[i] === '--migrate') {
       result.migrate = true;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -322,6 +322,29 @@ describe('loadConfig', () => {
     warnSpy.mockRestore();
   });
 
+  // --- logLevel ---
+
+  it('defaults logLevel to info', () => {
+    const config = loadConfig({ projects: { 'ch-1': { directory: '/tmp/a' } } });
+    expect(config.defaults.logLevel).toBe('info');
+  });
+
+  it('overrides logLevel from config', () => {
+    const config = loadConfig({
+      defaults: { logLevel: 'debug' },
+      projects: { 'ch-1': { directory: '/tmp/a' } },
+    });
+    expect(config.defaults.logLevel).toBe('debug');
+  });
+
+  it('falls back to info for invalid logLevel', () => {
+    const config = loadConfig({
+      defaults: { logLevel: 'verbose' },
+      projects: { 'ch-1': { directory: '/tmp/a' } },
+    });
+    expect(config.defaults.logLevel).toBe('info');
+  });
+
   it('omits allowedTools/disallowedTools from project when not specified', () => {
     const config = loadConfig({
       projects: { 'ch-1': { directory: '/tmp/a' } },

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createLogger,
+  shouldLog,
+  formatLogEntry,
+  parseLogEntry,
+  filterLogEntries,
+  isValidLogLevel,
+  type LogEntry,
+  type LogLevel,
+} from '../src/logger.js';
+
+describe('shouldLog', () => {
+  it('allows same level', () => {
+    expect(shouldLog('info', 'info')).toBe(true);
+  });
+
+  it('allows higher level', () => {
+    expect(shouldLog('error', 'info')).toBe(true);
+    expect(shouldLog('warn', 'debug')).toBe(true);
+  });
+
+  it('blocks lower level', () => {
+    expect(shouldLog('debug', 'info')).toBe(false);
+    expect(shouldLog('info', 'warn')).toBe(false);
+  });
+
+  it('debug allows all levels', () => {
+    expect(shouldLog('debug', 'debug')).toBe(true);
+    expect(shouldLog('info', 'debug')).toBe(true);
+    expect(shouldLog('warn', 'debug')).toBe(true);
+    expect(shouldLog('error', 'debug')).toBe(true);
+  });
+
+  it('error only allows error', () => {
+    expect(shouldLog('debug', 'error')).toBe(false);
+    expect(shouldLog('info', 'error')).toBe(false);
+    expect(shouldLog('warn', 'error')).toBe(false);
+    expect(shouldLog('error', 'error')).toBe(true);
+  });
+});
+
+describe('formatLogEntry', () => {
+  it('produces valid JSON', () => {
+    const entry: LogEntry = {
+      timestamp: '2026-03-25T12:00:00.000Z',
+      level: 'info',
+      message: 'test message',
+    };
+    const json = formatLogEntry(entry);
+    const parsed = JSON.parse(json);
+    expect(parsed.timestamp).toBe('2026-03-25T12:00:00.000Z');
+    expect(parsed.level).toBe('info');
+    expect(parsed.message).toBe('test message');
+  });
+
+  it('includes optional project and session fields', () => {
+    const entry: LogEntry = {
+      timestamp: '2026-03-25T12:00:00.000Z',
+      level: 'warn',
+      message: 'test',
+      project: 'my-app',
+      session: 'abc123',
+    };
+    const parsed = JSON.parse(formatLogEntry(entry));
+    expect(parsed.project).toBe('my-app');
+    expect(parsed.session).toBe('abc123');
+  });
+});
+
+describe('parseLogEntry', () => {
+  it('parses valid JSON log entry', () => {
+    const line = '{"timestamp":"2026-03-25T12:00:00.000Z","level":"info","message":"hello"}';
+    const entry = parseLogEntry(line);
+    expect(entry).not.toBeNull();
+    expect(entry!.level).toBe('info');
+    expect(entry!.message).toBe('hello');
+  });
+
+  it('returns null for invalid JSON', () => {
+    expect(parseLogEntry('not json')).toBeNull();
+  });
+
+  it('returns null for JSON missing required fields', () => {
+    expect(parseLogEntry('{"level":"info"}')).toBeNull();
+    expect(parseLogEntry('{"timestamp":"x","message":"y"}')).toBeNull();
+    expect(parseLogEntry('{"timestamp":"x","level":"info"}')).toBeNull();
+  });
+
+  it('returns null for invalid log level', () => {
+    expect(parseLogEntry('{"timestamp":"x","level":"trace","message":"y"}')).toBeNull();
+  });
+
+  it('preserves optional fields', () => {
+    const line = '{"timestamp":"t","level":"debug","message":"m","project":"p","session":"s"}';
+    const entry = parseLogEntry(line);
+    expect(entry!.project).toBe('p');
+    expect(entry!.session).toBe('s');
+  });
+});
+
+describe('filterLogEntries', () => {
+  const entries: LogEntry[] = [
+    { timestamp: 't1', level: 'debug', message: 'debug msg', project: 'alpha' },
+    { timestamp: 't2', level: 'info', message: 'info msg', project: 'beta' },
+    { timestamp: 't3', level: 'warn', message: 'warn msg', project: 'alpha' },
+    { timestamp: 't4', level: 'error', message: 'error msg', project: 'beta' },
+  ];
+
+  it('returns all entries with no filters', () => {
+    expect(filterLogEntries(entries)).toHaveLength(4);
+  });
+
+  it('filters by minimum level', () => {
+    const result = filterLogEntries(entries, { level: 'warn' });
+    expect(result).toHaveLength(2);
+    expect(result.map((e) => e.level)).toEqual(['warn', 'error']);
+  });
+
+  it('filters by project name', () => {
+    const result = filterLogEntries(entries, { project: 'alpha' });
+    expect(result).toHaveLength(2);
+    expect(result.every((e) => e.project === 'alpha')).toBe(true);
+  });
+
+  it('combines level and project filters', () => {
+    const result = filterLogEntries(entries, { project: 'beta', level: 'error' });
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toBe('error msg');
+  });
+
+  it('returns empty array when nothing matches', () => {
+    const result = filterLogEntries(entries, { project: 'nonexistent' });
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('isValidLogLevel', () => {
+  it('accepts valid levels', () => {
+    expect(isValidLogLevel('debug')).toBe(true);
+    expect(isValidLogLevel('info')).toBe(true);
+    expect(isValidLogLevel('warn')).toBe(true);
+    expect(isValidLogLevel('error')).toBe(true);
+  });
+
+  it('rejects invalid values', () => {
+    expect(isValidLogLevel('trace')).toBe(false);
+    expect(isValidLogLevel('verbose')).toBe(false);
+    expect(isValidLogLevel('')).toBe(false);
+    expect(isValidLogLevel(42)).toBe(false);
+    expect(isValidLogLevel(null)).toBe(false);
+  });
+});
+
+describe('createLogger', () => {
+  it('writes JSON log lines', () => {
+    const lines: string[] = [];
+    const logger = createLogger('debug', (line) => lines.push(line));
+
+    logger.info('test message');
+
+    expect(lines).toHaveLength(1);
+    const entry = JSON.parse(lines[0]);
+    expect(entry.level).toBe('info');
+    expect(entry.message).toBe('test message');
+    expect(entry.timestamp).toBeDefined();
+  });
+
+  it('respects minimum log level', () => {
+    const lines: string[] = [];
+    const logger = createLogger('warn', (line) => lines.push(line));
+
+    logger.debug('hidden');
+    logger.info('hidden');
+    logger.warn('visible');
+    logger.error('visible');
+
+    expect(lines).toHaveLength(2);
+  });
+
+  it('includes project and session context', () => {
+    const lines: string[] = [];
+    const logger = createLogger('debug', (line) => lines.push(line));
+
+    logger.info('connected', { project: 'my-app', session: 'sess-123' });
+
+    const entry = JSON.parse(lines[0]);
+    expect(entry.project).toBe('my-app');
+    expect(entry.session).toBe('sess-123');
+  });
+
+  it('omits project/session when not provided', () => {
+    const lines: string[] = [];
+    const logger = createLogger('debug', (line) => lines.push(line));
+
+    logger.info('plain message');
+
+    const entry = JSON.parse(lines[0]);
+    expect(entry.project).toBeUndefined();
+    expect(entry.session).toBeUndefined();
+  });
+
+  it('defaults to info level', () => {
+    const lines: string[] = [];
+    const logger = createLogger(undefined, (line) => lines.push(line));
+
+    logger.debug('hidden');
+    logger.info('visible');
+
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]).level).toBe('info');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `src/logger.ts` — structured JSON-line logger with `debug`/`info`/`warn`/`error` levels, configurable via `defaults.logLevel` in config (default: `info`)
- Add `mpg logs` CLI subcommand that reads structured log lines from stdin, with `--project <name>` and `--level <level>` filtering flags, and outputs human-readable formatted lines
- Replace key `console.log`/`console.warn`/`console.error` calls in the `start` flow with the new logger
- Add `logLevel` to `GatewayDefaults` in config.ts with validation and fallback

Closes #16

## Test plan
- [x] 24 unit tests for logger module (shouldLog, formatLogEntry, parseLogEntry, filterLogEntries, isValidLogLevel, createLogger)
- [x] 3 config tests for logLevel default, override, and invalid value fallback
- [x] All 225 tests pass (222 existing + 3 new config tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)