### PR TITLE
feat: web dashboard for session monitoring (#19)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -165,7 +165,7 @@ function start() {
     .then(async () => {
       if (config.defaults.httpPort !== false) {
         try {
-          healthServer = await createHealthServer(config.defaults.httpPort, sessionManager, bot);
+          healthServer = await createHealthServer(config.defaults.httpPort, sessionManager, bot, config);
         } catch (err) {
           log.warn(`Health server failed to start on port ${config.defaults.httpPort}: ${err}`);
         }

--- a/src/health-server.ts
+++ b/src/health-server.ts
@@ -1,35 +1,244 @@
 import { createServer, type Server } from 'node:http';
+import { readFileSync } from 'node:fs';
 import type { SessionManager } from './session-manager.js';
 import type { DiscordBot } from './discord.js';
+import type { GatewayConfig } from './config.js';
 
 export interface HealthServer {
   close(): Promise<void>;
+}
+
+function getVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
+    return pkg.version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function buildDashboardHtml(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MPG Dashboard</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0f1117; color: #e1e4e8; padding: 24px; }
+  h1 { font-size: 20px; font-weight: 600; margin-bottom: 4px; }
+  .subtitle { color: #8b949e; font-size: 13px; margin-bottom: 24px; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 16px; margin-bottom: 24px; }
+  .card { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px; }
+  .card-label { font-size: 12px; color: #8b949e; text-transform: uppercase; letter-spacing: 0.5px; }
+  .card-value { font-size: 28px; font-weight: 700; margin-top: 4px; }
+  .status-ok { color: #3fb950; }
+  .status-warn { color: #d29922; }
+  .status-err { color: #f85149; }
+  h2 { font-size: 16px; font-weight: 600; margin-bottom: 12px; }
+  table { width: 100%; border-collapse: collapse; background: #161b22; border: 1px solid #30363d; border-radius: 8px; overflow: hidden; margin-bottom: 24px; }
+  th { text-align: left; padding: 10px 14px; font-size: 12px; color: #8b949e; text-transform: uppercase; letter-spacing: 0.5px; border-bottom: 1px solid #30363d; }
+  td { padding: 10px 14px; font-size: 14px; border-bottom: 1px solid #21262d; }
+  tr:last-child td { border-bottom: none; }
+  .empty { color: #8b949e; font-style: italic; padding: 24px; text-align: center; }
+  .refresh-info { color: #484f58; font-size: 12px; text-align: right; }
+</style>
+</head>
+<body>
+<h1>Multi-Project Gateway</h1>
+<p class="subtitle" id="version"></p>
+
+<div class="grid">
+  <div class="card">
+    <div class="card-label">Status</div>
+    <div class="card-value" id="status">—</div>
+  </div>
+  <div class="card">
+    <div class="card-label">Uptime</div>
+    <div class="card-value" id="uptime">—</div>
+  </div>
+  <div class="card">
+    <div class="card-label">Active Sessions</div>
+    <div class="card-value" id="sessions-active">—</div>
+  </div>
+  <div class="card">
+    <div class="card-label">Queued Messages</div>
+    <div class="card-value" id="sessions-queued">—</div>
+  </div>
+  <div class="card">
+    <div class="card-label">Discord</div>
+    <div class="card-value" id="discord">—</div>
+  </div>
+</div>
+
+<h2>Sessions</h2>
+<div id="sessions-table"></div>
+
+<h2>Projects</h2>
+<div id="projects-table"></div>
+
+<p class="refresh-info">Auto-refreshes every 5s</p>
+
+<script>
+function formatUptime(s) {
+  if (s < 60) return s + 's';
+  if (s < 3600) return Math.floor(s / 60) + 'm';
+  var h = Math.floor(s / 3600);
+  var m = Math.floor((s % 3600) / 60);
+  return h + 'h ' + m + 'm';
+}
+function formatAgo(ts) {
+  var diff = Math.floor((Date.now() - ts) / 1000);
+  if (diff < 60) return diff + 's ago';
+  if (diff < 3600) return Math.floor(diff / 60) + 'm ago';
+  return Math.floor(diff / 3600) + 'h ago';
+}
+function statusClass(v) {
+  if (v === 'ok' || v === 'connected') return 'status-ok';
+  if (v === 'reconnecting') return 'status-warn';
+  return 'status-err';
+}
+function escapeHtml(s) {
+  var d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+
+function refresh() {
+  fetch('/api/status')
+    .then(function(r) { return r.json(); })
+    .then(function(d) {
+      document.getElementById('version').textContent = 'v' + d.version;
+      var statusEl = document.getElementById('status');
+      statusEl.textContent = d.health.status;
+      statusEl.className = 'card-value ' + statusClass(d.health.status);
+      document.getElementById('uptime').textContent = formatUptime(d.health.uptime);
+      document.getElementById('sessions-active').textContent = d.health.sessions.active;
+      document.getElementById('sessions-queued').textContent = d.health.sessions.queued;
+      var discordEl = document.getElementById('discord');
+      discordEl.textContent = d.health.discord;
+      discordEl.className = 'card-value ' + statusClass(d.health.discord);
+
+      // Sessions table
+      var st = document.getElementById('sessions-table');
+      if (d.sessions.length === 0) {
+        st.innerHTML = '<div class="empty">No active sessions</div>';
+      } else {
+        var h = '<table><tr><th>Project</th><th>Session ID</th><th>Last Activity</th><th>Queue</th></tr>';
+        for (var i = 0; i < d.sessions.length; i++) {
+          var s = d.sessions[i];
+          h += '<tr><td>' + escapeHtml(s.projectKey) + '</td><td>' + escapeHtml(s.sessionId ? s.sessionId.slice(0, 12) + '...' : '—') + '</td><td>' + formatAgo(s.lastActivity) + '</td><td>' + s.queueLength + '</td></tr>';
+        }
+        h += '</table>';
+        st.innerHTML = h;
+      }
+
+      // Projects table
+      var pt = document.getElementById('projects-table');
+      if (d.projects.length === 0) {
+        pt.innerHTML = '<div class="empty">No projects configured</div>';
+      } else {
+        var h2 = '<table><tr><th>Name</th><th>Directory</th><th>Agents</th></tr>';
+        for (var j = 0; j < d.projects.length; j++) {
+          var p = d.projects[j];
+          h2 += '<tr><td>' + escapeHtml(p.name) + '</td><td>' + escapeHtml(p.directory) + '</td><td>' + escapeHtml(p.agents.join(', ') || '—') + '</td></tr>';
+        }
+        h2 += '</table>';
+        pt.innerHTML = h2;
+      }
+    })
+    .catch(function() {
+      document.getElementById('status').textContent = 'error';
+      document.getElementById('status').className = 'card-value status-err';
+    });
+}
+
+refresh();
+setInterval(refresh, 5000);
+</script>
+</body>
+</html>`;
 }
 
 export function createHealthServer(
   port: number,
   sessionManager: SessionManager,
   bot: DiscordBot,
+  config?: GatewayConfig,
 ): Promise<HealthServer> {
   const startTime = Date.now();
+  const version = getVersion();
+  const dashboardHtml = buildDashboardHtml();
+
+  function getHealthData() {
+    const sessions = sessionManager.listSessions();
+    return {
+      status: 'ok',
+      uptime: Math.floor((Date.now() - startTime) / 1000),
+      sessions: {
+        active: sessions.length,
+        queued: sessions.reduce((sum, s) => sum + s.queueLength, 0),
+      },
+      discord: bot.getStatus(),
+    };
+  }
+
+  function getProjectsData() {
+    if (!config) return [];
+    return Object.entries(config.projects).map(([channelId, project]) => ({
+      channelId,
+      name: project.name,
+      directory: project.directory,
+      agents: project.agents ? Object.keys(project.agents) : [],
+    }));
+  }
 
   const server: Server = createServer((req, res) => {
     const { pathname } = new URL(req.url ?? '/', `http://localhost`);
-    if (req.method === 'GET' && pathname === '/health') {
-      const sessions = sessionManager.listSessions();
 
-      const body = JSON.stringify({
-        status: 'ok',
-        uptime: Math.floor((Date.now() - startTime) / 1000),
-        sessions: {
-          active: sessions.length,
-          queued: sessions.reduce((sum, s) => sum + s.queueLength, 0),
-        },
-        discord: bot.getStatus(),
-      });
+    if (req.method !== 'GET') {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Not Found' }));
+      return;
+    }
 
+    if (pathname === '/health') {
+      const body = JSON.stringify(getHealthData());
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(body);
+      return;
+    }
+
+    if (pathname === '/api/sessions') {
+      const body = JSON.stringify(sessionManager.listSessions());
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(body);
+      return;
+    }
+
+    if (pathname === '/api/projects') {
+      const body = JSON.stringify(getProjectsData());
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(body);
+      return;
+    }
+
+    if (pathname === '/api/status') {
+      const body = JSON.stringify({
+        version,
+        health: getHealthData(),
+        sessions: sessionManager.listSessions(),
+        projects: getProjectsData(),
+      });
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(body);
+      return;
+    }
+
+    if (pathname === '/') {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(dashboardHtml);
       return;
     }
 

--- a/tests/health-server.test.ts
+++ b/tests/health-server.test.ts
@@ -3,6 +3,7 @@ import { request } from 'node:http';
 import { createHealthServer, type HealthServer } from '../src/health-server.js';
 import type { SessionManager, SessionInfo } from '../src/session-manager.js';
 import type { DiscordBot } from '../src/discord.js';
+import type { GatewayConfig } from '../src/config.js';
 
 function makeSessionManager(sessions: SessionInfo[] = []): SessionManager {
   return {
@@ -23,6 +24,36 @@ function makeBot(status = 'connected'): DiscordBot {
   };
 }
 
+function makeConfig(overrides?: Partial<GatewayConfig>): GatewayConfig {
+  return {
+    defaults: {
+      idleTimeoutMs: 1800000,
+      maxConcurrentSessions: 4,
+      sessionTtlMs: 604800000,
+      maxPersistedSessions: 50,
+      claudeArgs: [],
+      allowedTools: [],
+      disallowedTools: [],
+      maxTurnsPerAgent: 5,
+      agentTimeoutMs: 180000,
+      httpPort: 3100,
+      logLevel: 'info',
+    },
+    projects: {
+      'ch-1': {
+        name: 'My Project',
+        directory: '/home/user/project',
+        agents: { pm: { role: 'PM', prompt: 'You are a PM' }, engineer: { role: 'Engineer', prompt: 'You are an engineer' } },
+      },
+      'ch-2': {
+        name: 'Other Project',
+        directory: '/home/user/other',
+      },
+    },
+    ...overrides,
+  };
+}
+
 function httpGet(port: number, path: string): Promise<{ status: number; body: string }> {
   return new Promise((resolve, reject) => {
     const req = request({ hostname: '127.0.0.1', port, path, method: 'GET' }, (res) => {
@@ -35,6 +66,10 @@ function httpGet(port: number, path: string): Promise<{ status: number; body: st
   });
 }
 
+// Use a port counter to avoid conflicts across tests
+let nextPort = 19876;
+function getPort() { return nextPort++; }
+
 describe('createHealthServer', () => {
   let server: HealthServer | undefined;
 
@@ -46,19 +81,11 @@ describe('createHealthServer', () => {
   });
 
   it('returns 200 with health JSON on GET /health', async () => {
+    const port = getPort();
     const sessions: SessionInfo[] = [
       { sessionId: 'sess-1', projectKey: 'ch-1', lastActivity: Date.now(), queueLength: 0 },
       { sessionId: 'sess-2', projectKey: 'ch-2', lastActivity: Date.now(), queueLength: 2 },
     ];
-    server = await createHealthServer(0, makeSessionManager(sessions), makeBot('connected'));
-
-    // Extract the actual port from the server (port 0 means OS-assigned)
-    const addr = (server as any);
-    // We need the actual port — use a different approach: pass a known port
-    await server.close();
-
-    // Use a specific port for the test
-    const port = 19876;
     server = await createHealthServer(port, makeSessionManager(sessions), makeBot('connected'));
 
     const res = await httpGet(port, '/health');
@@ -74,7 +101,7 @@ describe('createHealthServer', () => {
   });
 
   it('returns 404 for unknown routes', async () => {
-    const port = 19877;
+    const port = getPort();
     server = await createHealthServer(port, makeSessionManager(), makeBot());
 
     const res = await httpGet(port, '/unknown');
@@ -85,7 +112,7 @@ describe('createHealthServer', () => {
   });
 
   it('returns 404 for POST /health', async () => {
-    const port = 19878;
+    const port = getPort();
     server = await createHealthServer(port, makeSessionManager(), makeBot());
 
     const res = await new Promise<{ status: number; body: string }>((resolve, reject) => {
@@ -101,7 +128,7 @@ describe('createHealthServer', () => {
   });
 
   it('reports zero sessions when none exist', async () => {
-    const port = 19879;
+    const port = getPort();
     server = await createHealthServer(port, makeSessionManager([]), makeBot());
 
     const res = await httpGet(port, '/health');
@@ -111,7 +138,7 @@ describe('createHealthServer', () => {
   });
 
   it('reflects discord status from bot', async () => {
-    const port = 19880;
+    const port = getPort();
     server = await createHealthServer(port, makeSessionManager(), makeBot('reconnecting'));
 
     const res = await httpGet(port, '/health');
@@ -120,12 +147,119 @@ describe('createHealthServer', () => {
   });
 
   it('closes gracefully', async () => {
-    const port = 19881;
+    const port = getPort();
     server = await createHealthServer(port, makeSessionManager(), makeBot());
     await server.close();
     server = undefined;
 
     // Should fail to connect after close
     await expect(httpGet(port, '/health')).rejects.toThrow();
+  });
+
+  // --- New API endpoint tests ---
+
+  describe('GET /api/sessions', () => {
+    it('returns session list', async () => {
+      const port = getPort();
+      const sessions: SessionInfo[] = [
+        { sessionId: 'sess-1', projectKey: 'ch-1', lastActivity: 1700000000000, queueLength: 3 },
+      ];
+      server = await createHealthServer(port, makeSessionManager(sessions), makeBot());
+
+      const res = await httpGet(port, '/api/sessions');
+      expect(res.status).toBe(200);
+
+      const json = JSON.parse(res.body);
+      expect(json).toHaveLength(1);
+      expect(json[0].sessionId).toBe('sess-1');
+      expect(json[0].projectKey).toBe('ch-1');
+      expect(json[0].lastActivity).toBe(1700000000000);
+      expect(json[0].queueLength).toBe(3);
+    });
+
+    it('returns empty array when no sessions', async () => {
+      const port = getPort();
+      server = await createHealthServer(port, makeSessionManager([]), makeBot());
+
+      const res = await httpGet(port, '/api/sessions');
+      const json = JSON.parse(res.body);
+      expect(json).toEqual([]);
+    });
+  });
+
+  describe('GET /api/projects', () => {
+    it('returns project list with agents when config provided', async () => {
+      const port = getPort();
+      server = await createHealthServer(port, makeSessionManager(), makeBot(), makeConfig());
+
+      const res = await httpGet(port, '/api/projects');
+      expect(res.status).toBe(200);
+
+      const json = JSON.parse(res.body);
+      expect(json).toHaveLength(2);
+
+      const proj1 = json.find((p: any) => p.channelId === 'ch-1');
+      expect(proj1.name).toBe('My Project');
+      expect(proj1.directory).toBe('/home/user/project');
+      expect(proj1.agents).toEqual(['pm', 'engineer']);
+
+      const proj2 = json.find((p: any) => p.channelId === 'ch-2');
+      expect(proj2.name).toBe('Other Project');
+      expect(proj2.agents).toEqual([]);
+    });
+
+    it('returns empty array when no config provided', async () => {
+      const port = getPort();
+      server = await createHealthServer(port, makeSessionManager(), makeBot());
+
+      const res = await httpGet(port, '/api/projects');
+      const json = JSON.parse(res.body);
+      expect(json).toEqual([]);
+    });
+  });
+
+  describe('GET /api/status', () => {
+    it('returns combined status overview', async () => {
+      const port = getPort();
+      const sessions: SessionInfo[] = [
+        { sessionId: 'sess-1', projectKey: 'ch-1', lastActivity: Date.now(), queueLength: 1 },
+      ];
+      server = await createHealthServer(port, makeSessionManager(sessions), makeBot('connected'), makeConfig());
+
+      const res = await httpGet(port, '/api/status');
+      expect(res.status).toBe(200);
+
+      const json = JSON.parse(res.body);
+
+      // Version
+      expect(typeof json.version).toBe('string');
+
+      // Health sub-object
+      expect(json.health.status).toBe('ok');
+      expect(typeof json.health.uptime).toBe('number');
+      expect(json.health.sessions.active).toBe(1);
+      expect(json.health.sessions.queued).toBe(1);
+      expect(json.health.discord).toBe('connected');
+
+      // Sessions array
+      expect(json.sessions).toHaveLength(1);
+      expect(json.sessions[0].sessionId).toBe('sess-1');
+
+      // Projects array
+      expect(json.projects).toHaveLength(2);
+    });
+  });
+
+  describe('GET /', () => {
+    it('serves HTML dashboard', async () => {
+      const port = getPort();
+      server = await createHealthServer(port, makeSessionManager(), makeBot());
+
+      const res = await httpGet(port, '/');
+      expect(res.status).toBe(200);
+      expect(res.body).toContain('<!DOCTYPE html>');
+      expect(res.body).toContain('Multi-Project Gateway');
+      expect(res.body).toContain('/api/status');
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #19

- Add JSON API endpoints: `GET /api/sessions`, `GET /api/projects`, `GET /api/status`
- Serve an inline HTML dashboard at `GET /` with auto-refresh (5s polling)
- Dashboard displays: active sessions, queue depth, project list, Discord bot status, uptime, gateway version

## Design decisions

- **No new dependencies** — uses `node:http` + inline HTML/CSS/JS
- **Backward-compatible** — `config` parameter is optional; existing `/health` endpoint unchanged
- **Read-only** — all endpoints are GET, no mutations
- **Same port** — reuses existing `defaults.httpPort` (3100)

## Test plan

- [x] All 6 original health-server tests still pass
- [x] 6 new tests covering `/api/sessions`, `/api/projects`, `/api/status`, and `GET /`
- [x] Full suite: 254/254 tests pass
- [x] Build succeeds (`tsup` exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)