### PR TITLE
feat: add !ask command for human-to-agent dispatch

### DIFF
--- a/src/agent-dispatch.ts
+++ b/src/agent-dispatch.ts
@@ -9,6 +9,52 @@ export interface AgentMention {
   prompt: string;
 }
 
+/** Built-in command names that take precedence over agent shorthand (!<agent>). */
+const BUILT_IN_COMMANDS = new Set([
+  'help', 'sessions', 'session', 'kill', 'restart', 'agents', 'ask',
+]);
+
+/**
+ * Parse `!ask <agent> <message>` (canonical) or `!<agent> <message>` (shorthand).
+ * Shorthand yields to built-in commands — e.g. `!help` is never treated as an agent dispatch.
+ */
+export function parseAgentCommand(
+  text: string,
+  agents: Record<string, AgentConfig>,
+): AgentMention | null {
+  // Canonical form: !ask <agent> <message>
+  const askMatch = text.match(/^!ask\s+(\S+)(?:\s+([\s\S]*))?$/i);
+  if (askMatch) {
+    const name = askMatch[1].toLowerCase();
+    const agent = agents[name];
+    if (!agent) return null; // unknown agent — caller handles error
+    const prompt = (askMatch[2] ?? '').trim();
+    return { agentName: name, agent, prompt };
+  }
+
+  // Shorthand form: !<agent> <message> (only if not a built-in command)
+  const shortMatch = text.match(/^!(\S+)(?:\s+([\s\S]*))?$/i);
+  if (shortMatch) {
+    const name = shortMatch[1].toLowerCase();
+    if (BUILT_IN_COMMANDS.has(name)) return null; // built-in wins
+    const agent = agents[name];
+    if (!agent) return null;
+    const prompt = (shortMatch[2] ?? '').trim();
+    return { agentName: name, agent, prompt };
+  }
+
+  return null;
+}
+
+/**
+ * Extract the target agent name from a `!ask` command, even if the agent is unknown.
+ * Returns null if the message is not a `!ask` command at all.
+ */
+export function extractAskTarget(text: string): string | null {
+  const askMatch = text.match(/^!ask\s+(\S+)/i);
+  return askMatch ? askMatch[1].toLowerCase() : null;
+}
+
 export function parseAgentMention(
   text: string,
   agents: Record<string, AgentConfig>,

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -3,7 +3,7 @@ import type { Router } from './router.js';
 import type { SessionManager } from './session-manager.js';
 import type { GatewayConfig } from './config.js';
 import { buildToolArgs } from './claude-cli.js';
-import { parseAgentMention } from './agent-dispatch.js';
+import { parseAgentMention, parseAgentCommand, extractAskTarget } from './agent-dispatch.js';
 import { sendAgentMessage, buildHandoffEmbed } from './embed-format.js';
 import type { TurnCounter } from './turn-counter.js';
 import { hasAllowedRole } from './role-check.js';
@@ -158,14 +158,16 @@ export function handleCommand(
       return `**${context.projectName}** — No agents configured. Messages go to the default session.`;
     }
     const lines = Object.entries(project.agents).map(([name, agent]) =>
-      `- \`@${name}\` — ${agent.role}`
+      `- \`${name}\` — ${agent.role}`
     );
-    return `**${context.projectName} agents**\n${lines.join('\n')}\n\nMention an agent to dispatch: \`@pm review this\``;
+    return `**${context.projectName} agents**\n${lines.join('\n')}\n\nDispatch: \`!ask <agent> <message>\` or shorthand \`!<agent> <message>\``;
   }
 
   if (cmd === '!help') {
     return [
       '**Gateway commands**',
+      '`!ask <agent> <message>` — dispatch a message to a named agent',
+      '`!<agent> <message>` — shorthand for `!ask`',
       '`!sessions` — list all active sessions',
       '`!session` — show session for the current thread (or use `!session <name>`)',
       '`!restart <name>` — reset a session (fresh context, keeps worktree)',
@@ -228,6 +230,30 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
         if (response) {
           await message.channel.send(response);
           return;
+        }
+
+        // Check for !ask <agent> or !<agent> shorthand dispatch
+        const projectChannelId = parentId || resolved.channelId;
+        const project = config.projects[projectChannelId];
+        const agents = project?.agents;
+        if (agents) {
+          const askMention = parseAgentCommand(message.content, agents);
+          if (askMention) {
+            // Fall through to normal message handling — inject the parsed mention
+            // by rewriting message content to @agent form so the existing path picks it up
+          } else {
+            // Check if user tried !ask with an unknown agent name
+            const target = extractAskTarget(message.content);
+            if (target) {
+              const agentList = Object.entries(agents)
+                .map(([name, a]) => `\`${name}\` — ${a.role}`)
+                .join('\n- ');
+              await message.channel.send(
+                `Unknown agent \`${target}\`. Available agents:\n- ${agentList}\n\nUsage: \`!ask <agent> <message>\``,
+              );
+              return;
+            }
+          }
         }
       }
     }
@@ -307,8 +333,10 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
     // Reset turn counter on human messages
     if (turnCounter) turnCounter.reset(replyChannel.id);
 
-    // Check for @agent mention, fall back to last active agent in this thread (#48)
-    const mention = agents ? parseAgentMention(message.content, agents) : null;
+    // Check for !ask <agent> command, @agent mention, or fall back to last active agent (#48, #60)
+    const mention = agents
+      ? (parseAgentCommand(message.content, agents) ?? parseAgentMention(message.content, agents))
+      : null;
     const activeAgent = mention ?? (message.channel.isThread() ? lastActiveAgent.get(replyChannel.id) ?? null : null);
 
     // Use thread ID for session keys so each thread gets its own agent sessions.

--- a/tests/agent-dispatch.test.ts
+++ b/tests/agent-dispatch.test.ts
@@ -1,6 +1,6 @@
 // tests/agent-dispatch.test.ts
 import { describe, it, expect } from 'vitest';
-import { parseAgentMention, type AgentConfig } from '../src/agent-dispatch.js';
+import { parseAgentMention, parseAgentCommand, extractAskTarget, type AgentConfig } from '../src/agent-dispatch.js';
 
 const agents: Record<string, AgentConfig> = {
   pm: { role: 'Product Manager', prompt: 'You manage requirements.' },
@@ -58,5 +58,114 @@ describe('parseAgentMention', () => {
   it('preserves full message as prompt when mention is not at start', () => {
     const result = parseAgentMention('please @pm do something', agents);
     expect(result!.prompt).toBe('please @pm do something');
+  });
+});
+
+describe('parseAgentCommand', () => {
+  it('parses canonical !ask <agent> <message>', () => {
+    const result = parseAgentCommand('!ask pm review issue #10', agents);
+    expect(result).toEqual({
+      agentName: 'pm',
+      agent: agents.pm,
+      prompt: 'review issue #10',
+    });
+  });
+
+  it('parses shorthand !<agent> <message>', () => {
+    const result = parseAgentCommand('!engineer implement login', agents);
+    expect(result).toEqual({
+      agentName: 'engineer',
+      agent: agents.engineer,
+      prompt: 'implement login',
+    });
+  });
+
+  it('is case-insensitive for !ask', () => {
+    const result = parseAgentCommand('!ASK PM review this', agents);
+    expect(result).toEqual({
+      agentName: 'pm',
+      agent: agents.pm,
+      prompt: 'review this',
+    });
+  });
+
+  it('is case-insensitive for agent name', () => {
+    const result = parseAgentCommand('!ask PM review this', agents);
+    expect(result!.agentName).toBe('pm');
+  });
+
+  it('returns null for unknown agent in !ask', () => {
+    const result = parseAgentCommand('!ask tester check this', agents);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for unknown agent in shorthand', () => {
+    const result = parseAgentCommand('!tester check this', agents);
+    expect(result).toBeNull();
+  });
+
+  it('built-in commands take precedence over shorthand', () => {
+    // Even if there were an agent named "help", the shorthand should not match
+    const result = parseAgentCommand('!help', agents);
+    expect(result).toBeNull();
+  });
+
+  it('built-in commands win: !sessions, !kill, !restart, !agents', () => {
+    expect(parseAgentCommand('!sessions', agents)).toBeNull();
+    expect(parseAgentCommand('!kill Alpha', agents)).toBeNull();
+    expect(parseAgentCommand('!restart Alpha', agents)).toBeNull();
+    expect(parseAgentCommand('!agents', agents)).toBeNull();
+  });
+
+  it('handles !ask <agent> with no message (empty prompt)', () => {
+    const result = parseAgentCommand('!ask pm', agents);
+    expect(result).toEqual({
+      agentName: 'pm',
+      agent: agents.pm,
+      prompt: '',
+    });
+  });
+
+  it('handles shorthand !<agent> with no message', () => {
+    const result = parseAgentCommand('!pm', agents);
+    expect(result).toEqual({
+      agentName: 'pm',
+      agent: agents.pm,
+      prompt: '',
+    });
+  });
+
+  it('returns null for non-command text', () => {
+    expect(parseAgentCommand('hello world', agents)).toBeNull();
+    expect(parseAgentCommand('@pm review this', agents)).toBeNull();
+  });
+
+  it('preserves multiline prompt content', () => {
+    const result = parseAgentCommand('!ask engineer fix the bug\nhere is the stack trace', agents);
+    expect(result!.prompt).toBe('fix the bug\nhere is the stack trace');
+  });
+});
+
+describe('extractAskTarget', () => {
+  it('extracts agent name from !ask command', () => {
+    expect(extractAskTarget('!ask pm review this')).toBe('pm');
+  });
+
+  it('extracts unknown agent name', () => {
+    expect(extractAskTarget('!ask unknownbot do something')).toBe('unknownbot');
+  });
+
+  it('extracts agent name with no message', () => {
+    expect(extractAskTarget('!ask pm')).toBe('pm');
+  });
+
+  it('returns null for non-ask commands', () => {
+    expect(extractAskTarget('!help')).toBeNull();
+    expect(extractAskTarget('!sessions')).toBeNull();
+    expect(extractAskTarget('hello world')).toBeNull();
+  });
+
+  it('is case-insensitive', () => {
+    expect(extractAskTarget('!ASK PM review')).toBe('pm');
   });
 });

--- a/tests/discord.test.ts
+++ b/tests/discord.test.ts
@@ -202,9 +202,9 @@ describe('handleCommand', () => {
       isThread: false,
     });
     expect(result).toContain('my-app');
-    expect(result).toContain('@pm');
+    expect(result).toContain('`pm`');
     expect(result).toContain('Product Manager');
-    expect(result).toContain('@engineer');
+    expect(result).toContain('`engineer`');
     expect(result).toContain('Engineer');
   });
 
@@ -216,8 +216,8 @@ describe('handleCommand', () => {
       isThread: true,
     });
     expect(result).toContain('my-app');
-    expect(result).toContain('@pm');
-    expect(result).toContain('@engineer');
+    expect(result).toContain('`pm`');
+    expect(result).toContain('`engineer`');
   });
 
   it('returns no agents message for project without agents', () => {
@@ -240,6 +240,25 @@ describe('handleCommand', () => {
     const sm = mockSessionManager();
     const result = handleCommand('!help', testConfig, sm);
     expect(result).toContain('!agents');
+  });
+
+  it('includes !ask in !help output', () => {
+    const sm = mockSessionManager();
+    const result = handleCommand('!help', testConfig, sm);
+    expect(result).toContain('!ask');
+    expect(result).toContain('dispatch a message to a named agent');
+  });
+
+  it('!agents output shows !ask dispatch syntax', () => {
+    const sm = mockSessionManager();
+    const result = handleCommand('!agents', configWithAgents, sm, {
+      channelId: 'ch-1',
+      projectName: 'my-app',
+      isThread: false,
+    });
+    expect(result).toContain('!ask');
+    expect(result).toContain('pm');
+    expect(result).toContain('engineer');
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #60

- Adds `!ask <agent> <message>` as the canonical way for **humans** to dispatch messages to agents in Discord
- Adds `!<agent> <message>` shorthand (built-in commands like `!help`, `!sessions` always win)
- `@agent` routing is **unchanged** — still works for both humans and agent-to-agent handoffs
- Unknown agent in `!ask` returns a helpful error listing available agents
- Updated `!help` and `!agents` output to document the new syntax

## Files changed

| File | Change |
|------|--------|
| `src/agent-dispatch.ts` | Added `parseAgentCommand()`, `extractAskTarget()`, `BUILT_IN_COMMANDS` set |
| `src/discord.ts` | Wired `!ask` into command handler; updated `!help` and `!agents` output |
| `tests/agent-dispatch.test.ts` | +17 new tests for `parseAgentCommand` and `extractAskTarget` |
| `tests/discord.test.ts` | +2 new tests, 2 updated for new `!agents` output format |

## Test plan

- [x] All 267 tests pass
- [x] TypeScript compiles clean
- [ ] Manual test: `!ask pm review this` dispatches to PM agent
- [ ] Manual test: `!pm review this` shorthand works
- [ ] Manual test: `!ask unknownagent` returns helpful error
- [ ] Manual test: `!help` shows `!ask` syntax
- [ ] Manual test: `@pm review this` still works (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)