### PR TITLE
fix: improve typing indicator during multi-agent handoffs

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -421,13 +421,11 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
 
           replyChannel.sendTyping().catch(() => {});
 
-          // Post handoff announcement — non-blocking so a failed send doesn't prevent the handoff (#56)
-          const announcement = await replyChannel.send({ embeds: [buildHandoffEmbed(handoff.agentName, handoff.agent.role)] }).catch(() => null);
-          const deleteAnnouncement = () => {
-            if (announcement && 'delete' in announcement) {
-              (announcement as { delete(): Promise<unknown> }).delete().catch(() => {});
-            }
-          };
+          // Post handoff announcement — kept visible so users see progress during long agent runs (#56, #65)
+          await replyChannel.send({ embeds: [buildHandoffEmbed(handoff.agentName, handoff.agent.role)] }).catch(() => null);
+
+          // Restore typing indicator — posting the announcement clears it (#65)
+          replyChannel.sendTyping().catch(() => {});
 
           console.log(`[handoff] thread=${replyChannel.id} sending to ${handoff.agentName} (key=${handoffKey}, prompt length=${responseText.length})`);
           const sendStart = Date.now();
@@ -443,7 +441,6 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
           } catch (handoffErr) {
             const msg = handoffErr instanceof Error ? handoffErr.message : String(handoffErr);
             console.log(`[handoff] thread=${replyChannel.id} ${handoff.agentName} failed: ${msg}`);
-            deleteAnnouncement();
             await replyChannel.send(
               `⚠️ Agent \`@${handoff.agentName}\` failed: ${msg.slice(0, 1800)}`
             );
@@ -452,9 +449,6 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
 
           const elapsed = ((Date.now() - sendStart) / 1000).toFixed(1);
           console.log(`[handoff] thread=${replyChannel.id} ${handoff.agentName} responded in ${elapsed}s (${handoffResult.text.length} chars)`);
-
-          // Remove announcement now that the response is posted (#56)
-          deleteAnnouncement();
 
           await sendAgentMessage(
             replyChannel,


### PR DESCRIPTION
## Summary
- Keep handoff announcement embeds visible instead of deleting them, giving users persistent feedback that an agent is working
- Send `sendTyping()` immediately after posting the announcement embed (posting a message clears Discord's typing state, leaving a gap until the next interval tick)
- Removes the `deleteAnnouncement` logic that was hiding progress indicators

Fixes #65

## Test plan
- [x] All 273 tests pass
- [x] TypeScript compiles clean
- [ ] Manual: trigger a multi-agent handoff (e.g. PM dispatches to engineer) and verify the "Handing off to @engineer..." embed stays visible during processing
- [ ] Manual: verify typing indicator appears continuously during agent work

🤖 Generated with [Claude Code](https://claude.com/claude-code)