### PR TITLE
feat(#91): add session timeline chart with idle/processing visualization

### DIFF
--- a/src/activity-engine.ts
+++ b/src/activity-engine.ts
@@ -104,6 +104,15 @@ export interface ActivityEngine {
     cache_read_tokens: number;
     cache_hit_ratio: number;
   };
+  sessionTimeline(range: TimeRange): Array<{
+    session_id: string;
+    label: string;
+    segments: Array<{
+      start: string;
+      end: string;
+      state: 'processing' | 'idle';
+    }>;
+  }>;
 }
 
 export function createActivityEngine(filePath?: string): ActivityEngine {
@@ -221,6 +230,86 @@ export function createActivityEngine(filePath?: string): ActivityEngine {
         cache_read_tokens: cacheRead,
         cache_hit_ratio: denominator > 0 ? cacheRead / denominator : 0,
       };
+    },
+
+    sessionTimeline(range) {
+      const events = readEvents(target, range);
+      const TIMELINE_TYPES = new Set(['session_start', 'message_routed', 'message_completed', 'session_end', 'session_idle']);
+      const relevant = events.filter(e => TIMELINE_TYPES.has(e.event_type));
+
+      // Group by session_id
+      const sessionMap = new Map<string, PulseEvent[]>();
+      for (const e of relevant) {
+        const list = sessionMap.get(e.session_id);
+        if (list) list.push(e);
+        else sessionMap.set(e.session_id, [e]);
+      }
+
+      const result: Array<{
+        session_id: string;
+        label: string;
+        segments: Array<{ start: string; end: string; state: 'processing' | 'idle' }>;
+      }> = [];
+
+      for (const [sessionId, sessionEvents] of sessionMap) {
+        // Sort by timestamp
+        sessionEvents.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+
+        // Determine persona: prefer agent_name from session_start, then agent_target from message_routed
+        let persona = 'default';
+        const startEvent = sessionEvents.find(e => e.event_type === 'session_start');
+        if (startEvent && startEvent.agent_name) {
+          persona = String(startEvent.agent_name);
+        } else {
+          const routedEvent = sessionEvents.find(e => e.event_type === 'message_routed');
+          if (routedEvent && routedEvent.agent_target) {
+            persona = String(routedEvent.agent_target);
+          }
+        }
+
+        const shortId = sessionId.substring(0, 8);
+        const label = `mpg/${shortId}/${persona}`;
+
+        // Build segments by walking through events
+        const segments: Array<{ start: string; end: string; state: 'processing' | 'idle' }> = [];
+        let currentState: 'processing' | 'idle' = 'idle';
+        let segmentStart = sessionEvents[0].timestamp;
+
+        for (let i = 1; i < sessionEvents.length; i++) {
+          const e = sessionEvents[i];
+
+          if (e.event_type === 'message_routed' && currentState === 'idle') {
+            // End idle segment, start processing
+            segments.push({ start: segmentStart, end: e.timestamp, state: 'idle' });
+            segmentStart = e.timestamp;
+            currentState = 'processing';
+          } else if (e.event_type === 'message_completed' && currentState === 'processing') {
+            // End processing segment, back to idle
+            segments.push({ start: segmentStart, end: e.timestamp, state: 'processing' });
+            segmentStart = e.timestamp;
+            currentState = 'idle';
+          } else if (e.event_type === 'session_end' || e.event_type === 'session_idle') {
+            // End whatever current state is
+            segments.push({ start: segmentStart, end: e.timestamp, state: currentState });
+            segmentStart = e.timestamp;
+          }
+        }
+
+        // If session has no end event but had activity, close the last segment
+        const lastEvent = sessionEvents[sessionEvents.length - 1];
+        if (lastEvent.event_type !== 'session_end' && lastEvent.event_type !== 'session_idle') {
+          if (segmentStart !== lastEvent.timestamp || segments.length === 0) {
+            // Only add if there's actually a segment to close
+            if (segments.length > 0 || sessionEvents.length > 1) {
+              segments.push({ start: segmentStart, end: lastEvent.timestamp, state: currentState });
+            }
+          }
+        }
+
+        result.push({ session_id: sessionId, label, segments });
+      }
+
+      return result;
     },
   };
 }

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -119,6 +119,7 @@ function buildDashboardHtml(): string {
     <div class="summary-card"><div class="summary-value" id="total-messages">0</div><div class="summary-label">Messages</div></div>
     <div class="summary-card"><div class="summary-value" id="avg-duration">0m</div><div class="summary-label">Avg Duration</div></div>
   </div>
+  <div class="chart-card" style="margin-bottom:16px"><h3>Session Timeline</h3><canvas id="timeline-chart"></canvas></div>
   <div class="chart-grid">
     <div class="chart-card"><h3>Messages Over Time</h3><canvas id="messages-chart"></canvas></div>
     <div class="chart-card"><h3>Cost Over Time</h3><canvas id="cost-chart"></canvas></div>
@@ -307,8 +308,119 @@ function timeAxisOptions(isHourBucket) {
   };
 }
 
+function formatSegmentDuration(startIso, endIso) {
+  var ms = new Date(endIso).getTime() - new Date(startIso).getTime();
+  if (ms < 1000) return ms + 'ms';
+  var s = Math.floor(ms / 1000);
+  if (s < 60) return s + 's';
+  var m = Math.floor(s / 60);
+  s = s % 60;
+  if (m < 60) return m + 'm ' + s + 's';
+  var h = Math.floor(m / 60);
+  m = m % 60;
+  return h + 'h ' + m + 'm';
+}
+
+function refreshTimeline() {
+  fetch('/api/activity/timeline?range=' + currentRange)
+    .then(function(r) { return r.json(); })
+    .then(function(sessions) {
+      destroyChart('timeline');
+      if (!sessions || sessions.length === 0) {
+        var ctx = document.getElementById('timeline-chart');
+        chartInstances['timeline'] = new Chart(ctx, {
+          type: 'bar',
+          data: { labels: [], datasets: [] },
+          options: { indexAxis: 'y', plugins: { legend: { display: false }, title: { display: true, text: 'No session data', color: '#8b949e' } } }
+        });
+        return;
+      }
+      var labels = sessions.map(function(s) { return s.label; });
+      var datasets = [];
+      // Find max segments across all sessions
+      var maxSegs = 0;
+      sessions.forEach(function(s) { if (s.segments.length > maxSegs) maxSegs = s.segments.length; });
+      for (var si = 0; si < maxSegs; si++) {
+        datasets.push({
+          label: 'Segment ' + si,
+          data: sessions.map(function(s) {
+            var seg = s.segments[si];
+            if (!seg) return null;
+            return [new Date(seg.start).getTime(), new Date(seg.end).getTime()];
+          }),
+          backgroundColor: sessions.map(function(s) {
+            var seg = s.segments[si];
+            if (!seg) return 'transparent';
+            return seg.state === 'processing' ? '#3fb950' : '#30363d';
+          }),
+          borderWidth: 0,
+          borderSkipped: false,
+          barPercentage: 0.6,
+          _segments: sessions.map(function(s) { return s.segments[si] || null; }),
+          _labels: labels,
+        });
+      }
+      chartInstances['timeline'] = new Chart(document.getElementById('timeline-chart'), {
+        type: 'bar',
+        data: { labels: labels, datasets: datasets },
+        options: {
+          indexAxis: 'y',
+          responsive: true,
+          maintainAspectRatio: false,
+          scales: {
+            x: {
+              type: 'linear',
+              position: 'top',
+              ticks: {
+                color: '#8b949e',
+                callback: function(value) {
+                  var d = new Date(value);
+                  var hh = String(d.getHours()).padStart(2, '0');
+                  var mm = String(d.getMinutes()).padStart(2, '0');
+                  var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+                  return months[d.getMonth()] + ' ' + d.getDate() + ' ' + hh + ':' + mm;
+                }
+              },
+              grid: { color: '#30363d' }
+            },
+            y: {
+              ticks: { color: '#8b949e', font: { family: 'monospace', size: 11 } },
+              grid: { display: false }
+            }
+          },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                title: function(items) {
+                  if (!items.length) return '';
+                  var ds = items[0].dataset;
+                  return ds._labels[items[0].dataIndex];
+                },
+                label: function(item) {
+                  var seg = item.dataset._segments[item.dataIndex];
+                  if (!seg) return '';
+                  var state = seg.state.charAt(0).toUpperCase() + seg.state.slice(1);
+                  return state + ': ' + formatSegmentDuration(seg.start, seg.end);
+                }
+              }
+            }
+          }
+        }
+      });
+      // Set canvas height based on session count
+      var canvas = document.getElementById('timeline-chart');
+      var minH = Math.max(120, sessions.length * 36 + 60);
+      canvas.parentElement.style.minHeight = minH + 'px';
+      canvas.style.height = minH + 'px';
+      chartInstances['timeline'].resize();
+    })
+    .catch(function(err) { console.error('Timeline fetch error:', err); });
+}
+
 function refreshActivity() {
   var isHourBucket = currentRange === '24h';
+  refreshTimeline();
   fetch('/api/activity/summary?range=' + currentRange)
     .then(function(r) { return r.json(); })
     .then(function(d) {
@@ -510,6 +622,31 @@ export function createDashboardServer(
       });
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(body);
+      return;
+    }
+
+    if (pathname === '/api/activity/timeline') {
+      const url = new URL(req.url ?? '/', `http://localhost`);
+      const rangeParam = url.searchParams.get('range') || '7d';
+      if (rangeParam !== '24h' && rangeParam !== '7d' && rangeParam !== '30d') {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid range. Must be 24h, 7d, or 30d' }));
+        return;
+      }
+      const engine = options?.activityEngine;
+      if (!engine) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify([]));
+        return;
+      }
+      try {
+        const data = engine.sessionTimeline(rangeParam as TimeRange);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(data));
+      } catch {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Failed to compute timeline data' }));
+      }
       return;
     }
 

--- a/tests/activity-engine.test.ts
+++ b/tests/activity-engine.test.ts
@@ -223,6 +223,167 @@ describe('ActivityEngine', () => {
     });
   });
 
+  describe('sessionTimeline', () => {
+    it('returns empty array for missing file', () => {
+      const engine = createActivityEngine(join(dir, 'nonexistent.jsonl'));
+      const timeline = engine.sessionTimeline('7d');
+      expect(timeline).toEqual([]);
+    });
+
+    it('reconstructs processing and idle segments from pulse events', () => {
+      const t0 = new Date('2026-03-29T10:00:00Z');
+      const t1 = new Date('2026-03-29T10:01:00Z');
+      const t2 = new Date('2026-03-29T10:05:00Z');
+      const t3 = new Date('2026-03-29T10:06:00Z');
+      writeEvents(filePath, [
+        makeEvent({ event_type: 'session_start', session_id: 'sess-abc12345xyz', timestamp: t0.toISOString(), agent_name: 'engineer' }),
+        makeEvent({ event_type: 'message_routed', session_id: 'sess-abc12345xyz', timestamp: t1.toISOString(), agent_target: 'engineer' }),
+        makeEvent({ event_type: 'message_completed', session_id: 'sess-abc12345xyz', timestamp: t2.toISOString(), agent_target: 'engineer' }),
+        makeEvent({ event_type: 'session_end', session_id: 'sess-abc12345xyz', timestamp: t3.toISOString(), duration_ms: 360000 }),
+      ]);
+      const engine = createActivityEngine(filePath);
+      const timeline = engine.sessionTimeline('7d');
+      expect(timeline).toHaveLength(1);
+      expect(timeline[0].session_id).toBe('sess-abc12345xyz');
+      expect(timeline[0].label).toBe('mpg/sess-abc/engineer');
+      expect(timeline[0].segments).toHaveLength(3);
+      // idle: session_start → message_routed
+      expect(timeline[0].segments[0]).toEqual({
+        start: t0.toISOString(),
+        end: t1.toISOString(),
+        state: 'idle',
+      });
+      // processing: message_routed → message_completed
+      expect(timeline[0].segments[1]).toEqual({
+        start: t1.toISOString(),
+        end: t2.toISOString(),
+        state: 'processing',
+      });
+      // idle: message_completed → session_end
+      expect(timeline[0].segments[2]).toEqual({
+        start: t2.toISOString(),
+        end: t3.toISOString(),
+        state: 'idle',
+      });
+    });
+
+    it('handles multiple processing bursts in a single session', () => {
+      const t0 = new Date('2026-03-29T10:00:00Z');
+      const t1 = new Date('2026-03-29T10:01:00Z');
+      const t2 = new Date('2026-03-29T10:02:00Z');
+      const t3 = new Date('2026-03-29T10:03:00Z');
+      const t4 = new Date('2026-03-29T10:04:00Z');
+      const t5 = new Date('2026-03-29T10:05:00Z');
+      writeEvents(filePath, [
+        makeEvent({ event_type: 'session_start', session_id: 'sess-multi000', timestamp: t0.toISOString(), agent_name: 'pm' }),
+        makeEvent({ event_type: 'message_routed', session_id: 'sess-multi000', timestamp: t1.toISOString(), agent_target: 'pm' }),
+        makeEvent({ event_type: 'message_completed', session_id: 'sess-multi000', timestamp: t2.toISOString() }),
+        makeEvent({ event_type: 'message_routed', session_id: 'sess-multi000', timestamp: t3.toISOString(), agent_target: 'pm' }),
+        makeEvent({ event_type: 'message_completed', session_id: 'sess-multi000', timestamp: t4.toISOString() }),
+        makeEvent({ event_type: 'session_end', session_id: 'sess-multi000', timestamp: t5.toISOString() }),
+      ]);
+      const engine = createActivityEngine(filePath);
+      const timeline = engine.sessionTimeline('7d');
+      expect(timeline).toHaveLength(1);
+      expect(timeline[0].segments).toHaveLength(5);
+      expect(timeline[0].segments.map(s => s.state)).toEqual([
+        'idle', 'processing', 'idle', 'processing', 'idle',
+      ]);
+    });
+
+    it('uses agent_name from session_start for label, falls back to agent_target', () => {
+      const t0 = new Date('2026-03-29T10:00:00Z');
+      const t1 = new Date('2026-03-29T10:01:00Z');
+      writeEvents(filePath, [
+        makeEvent({ event_type: 'session_start', session_id: 'sess-noagent0', timestamp: t0.toISOString() }),
+        makeEvent({ event_type: 'message_routed', session_id: 'sess-noagent0', timestamp: t0.toISOString(), agent_target: 'designer' }),
+        makeEvent({ event_type: 'session_end', session_id: 'sess-noagent0', timestamp: t1.toISOString() }),
+      ]);
+      const engine = createActivityEngine(filePath);
+      const timeline = engine.sessionTimeline('7d');
+      expect(timeline[0].label).toBe('mpg/sess-noa/designer');
+    });
+
+    it('falls back to "default" when no agent info available', () => {
+      const t0 = new Date('2026-03-29T10:00:00Z');
+      const t1 = new Date('2026-03-29T10:01:00Z');
+      writeEvents(filePath, [
+        makeEvent({ event_type: 'session_start', session_id: 'sess-bare0000', timestamp: t0.toISOString() }),
+        makeEvent({ event_type: 'session_end', session_id: 'sess-bare0000', timestamp: t1.toISOString() }),
+      ]);
+      const engine = createActivityEngine(filePath);
+      const timeline = engine.sessionTimeline('7d');
+      expect(timeline[0].label).toBe('mpg/sess-bar/default');
+    });
+
+    it('handles session_idle as session end', () => {
+      const t0 = new Date('2026-03-29T10:00:00Z');
+      const t1 = new Date('2026-03-29T10:05:00Z');
+      writeEvents(filePath, [
+        makeEvent({ event_type: 'session_start', session_id: 'sess-idle0000', timestamp: t0.toISOString() }),
+        makeEvent({ event_type: 'session_idle', session_id: 'sess-idle0000', timestamp: t1.toISOString() }),
+      ]);
+      const engine = createActivityEngine(filePath);
+      const timeline = engine.sessionTimeline('7d');
+      expect(timeline).toHaveLength(1);
+      expect(timeline[0].segments).toHaveLength(1);
+      expect(timeline[0].segments[0].state).toBe('idle');
+      expect(timeline[0].segments[0].end).toBe(t1.toISOString());
+    });
+
+    it('handles multiple sessions', () => {
+      const t0 = new Date('2026-03-29T10:00:00Z');
+      const t1 = new Date('2026-03-29T10:01:00Z');
+      const t2 = new Date('2026-03-29T10:02:00Z');
+      const t3 = new Date('2026-03-29T10:03:00Z');
+      writeEvents(filePath, [
+        makeEvent({ event_type: 'session_start', session_id: 'sess-aaaa0000', timestamp: t0.toISOString(), agent_name: 'pm' }),
+        makeEvent({ event_type: 'session_start', session_id: 'sess-bbbb0000', timestamp: t1.toISOString(), agent_name: 'engineer' }),
+        makeEvent({ event_type: 'session_end', session_id: 'sess-aaaa0000', timestamp: t2.toISOString() }),
+        makeEvent({ event_type: 'session_end', session_id: 'sess-bbbb0000', timestamp: t3.toISOString() }),
+      ]);
+      const engine = createActivityEngine(filePath);
+      const timeline = engine.sessionTimeline('7d');
+      expect(timeline).toHaveLength(2);
+      const labels = timeline.map(t => t.label);
+      expect(labels).toContain('mpg/sess-aaa/pm');
+      expect(labels).toContain('mpg/sess-bbb/engineer');
+    });
+
+    it('filters by time range', () => {
+      const old = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
+      const recent = new Date();
+      writeEvents(filePath, [
+        makeEvent({ event_type: 'session_start', session_id: 'sess-old00000', timestamp: old.toISOString() }),
+        makeEvent({ event_type: 'session_end', session_id: 'sess-old00000', timestamp: old.toISOString() }),
+        makeEvent({ event_type: 'session_start', session_id: 'sess-new00000', timestamp: recent.toISOString() }),
+        makeEvent({ event_type: 'session_end', session_id: 'sess-new00000', timestamp: recent.toISOString() }),
+      ]);
+      const engine = createActivityEngine(filePath);
+      expect(engine.sessionTimeline('7d')).toHaveLength(1);
+      expect(engine.sessionTimeline('30d')).toHaveLength(2);
+    });
+
+    it('handles session with no end event (uses last event timestamp)', () => {
+      const t0 = new Date('2026-03-29T10:00:00Z');
+      const t1 = new Date('2026-03-29T10:01:00Z');
+      const t2 = new Date('2026-03-29T10:05:00Z');
+      writeEvents(filePath, [
+        makeEvent({ event_type: 'session_start', session_id: 'sess-noend000', timestamp: t0.toISOString(), agent_name: 'pm' }),
+        makeEvent({ event_type: 'message_routed', session_id: 'sess-noend000', timestamp: t1.toISOString(), agent_target: 'pm' }),
+        makeEvent({ event_type: 'message_completed', session_id: 'sess-noend000', timestamp: t2.toISOString() }),
+      ]);
+      const engine = createActivityEngine(filePath);
+      const timeline = engine.sessionTimeline('7d');
+      expect(timeline).toHaveLength(1);
+      // Should still have segments up to last known event
+      expect(timeline[0].segments).toHaveLength(2);
+      expect(timeline[0].segments[0].state).toBe('idle');
+      expect(timeline[0].segments[1].state).toBe('processing');
+      expect(timeline[0].segments[1].end).toBe(t2.toISOString());
+    });
+  });
+
   it('skips malformed JSONL lines without crashing', () => {
     writeFileSync(filePath, '{"event_type":"session_start","timestamp":"' + new Date().toISOString() + '","session_id":"s","project_key":"p","project_dir":"d"}\nNOT JSON\n');
     const engine = createActivityEngine(filePath);

--- a/tests/dashboard-server.test.ts
+++ b/tests/dashboard-server.test.ts
@@ -268,6 +268,7 @@ describe('createDashboardServer', () => {
         modelBreakdown: vi.fn().mockReturnValue([{ model: 'claude-sonnet-4-20250514', input_tokens: 500000, output_tokens: 50000, cost_usd: 1.23 }]),
         personaBreakdown: vi.fn().mockReturnValue([{ agent: 'engineer', count: 25 }]),
         cacheEfficiency: vi.fn().mockReturnValue({ total_input_tokens: 500000, cache_read_tokens: 200000, cache_hit_ratio: 0.4 }),
+        sessionTimeline: vi.fn().mockReturnValue([]),
       };
     }
 
@@ -325,6 +326,64 @@ describe('createDashboardServer', () => {
       const res = await httpGet(port, '/api/activity/summary?range=7d');
       const body = JSON.parse(res.body);
       expect(body.project_name_map).toEqual({ 'ch-1': 'My Project', 'ch-2': 'Other Project' });
+    });
+  });
+
+  describe('GET /api/activity/timeline', () => {
+    function makeMockEngine() {
+      return {
+        computeSummary: vi.fn().mockReturnValue({
+          total_cost_usd: 0, total_input_tokens: 0, total_output_tokens: 0,
+          total_sessions: 0, total_messages: 0, avg_session_duration_ms: 0,
+        }),
+        tokensByProject: vi.fn().mockReturnValue([]),
+        tokensBySession: vi.fn().mockReturnValue([]),
+        bucketed: vi.fn().mockReturnValue([]),
+        sessionDurations: vi.fn().mockReturnValue([]),
+        modelBreakdown: vi.fn().mockReturnValue([]),
+        personaBreakdown: vi.fn().mockReturnValue([]),
+        cacheEfficiency: vi.fn().mockReturnValue({ total_input_tokens: 0, cache_read_tokens: 0, cache_hit_ratio: 0 }),
+        sessionTimeline: vi.fn().mockReturnValue([
+          {
+            session_id: 'sess-12345678',
+            label: 'mpg/sess-123/engineer',
+            segments: [
+              { start: '2026-03-29T10:00:00Z', end: '2026-03-29T10:01:00Z', state: 'idle' },
+              { start: '2026-03-29T10:01:00Z', end: '2026-03-29T10:05:00Z', state: 'processing' },
+            ],
+          },
+        ]),
+      };
+    }
+
+    it('returns timeline data from engine', async () => {
+      const port = getPort();
+      const engine = makeMockEngine();
+      server = await createDashboardServer(port, makeSessionManager(), makeBot(), makeConfig(), {
+        activityEngine: engine,
+      });
+      const res = await httpGet(port, '/api/activity/timeline?range=24h');
+      expect(res.status).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body).toHaveLength(1);
+      expect(body[0].label).toBe('mpg/sess-123/engineer');
+      expect(body[0].segments).toHaveLength(2);
+      expect(engine.sessionTimeline).toHaveBeenCalledWith('24h');
+    });
+
+    it('returns empty array when no engine provided', async () => {
+      const port = getPort();
+      server = await createDashboardServer(port, makeSessionManager(), makeBot(), makeConfig());
+      const res = await httpGet(port, '/api/activity/timeline?range=7d');
+      expect(res.status).toBe(200);
+      expect(JSON.parse(res.body)).toEqual([]);
+    });
+
+    it('returns 400 for invalid range', async () => {
+      const port = getPort();
+      server = await createDashboardServer(port, makeSessionManager(), makeBot(), makeConfig());
+      const res = await httpGet(port, '/api/activity/timeline?range=1y');
+      expect(res.status).toBe(400);
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #91. Adds a Gantt-style session timeline chart to the Activity tab, showing per-session processing vs idle segments over time.

**Changes across 4 files:**

- **`src/activity-engine.ts`** — New `sessionTimeline(range)` method on `ActivityEngine` interface. Reconstructs idle/processing segments from pulse events (`session_start` → `message_routed` → `message_completed` → `session_end`/`session_idle`). Labels use `mpg/{first 8 chars}/{agent_name or "default"}` format.
- **`src/dashboard-server.ts`** — New `GET /api/activity/timeline?range=24h|7d|30d` endpoint. Gantt-style Chart.js floating bar chart at the top of the Activity tab (green = processing, gray = idle). Tooltip shows session label, state, and duration. Respects existing time range selector and dark theme.
- **`tests/activity-engine.test.ts`** — 9 new unit tests covering: empty file, segment reconstruction, multiple processing bursts, label fallback (agent_name → agent_target → default), session_idle as end event, multiple sessions, time range filtering, no-end-event sessions.
- **`tests/dashboard-server.test.ts`** — 3 new tests for the timeline API endpoint: returns data, empty without engine, 400 on invalid range.

## Test plan

- [x] All 375 tests pass (372 existing + 12 new)
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [ ] Manual: open dashboard Activity tab, verify timeline chart renders at top
- [ ] Manual: switch time ranges (24h/7d/30d), verify chart updates
- [ ] Manual: hover segments, verify tooltip shows label + state + duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)