### PR TITLE
fix: sync activity tab default range with active UI button

### DIFF
--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -282,7 +282,7 @@ refresh();
 setInterval(refresh, 5000);
 
 var chartInstances = {};
-var currentRange = '7d';
+var currentRange = '24h';
 var timelineRange = '24h';
 var CHART_COLORS = ['#58a6ff', '#3fb950', '#d29922', '#f85149', '#bc8cff', '#79c0ff'];
 


### PR DESCRIPTION
## Summary
- The JS variable `currentRange` defaulted to `'7d'` while the HTML had `24h` as the initially active button
- This caused the first activity tab render to fetch 7-day data while the UI showed 24h selected
- Toggling the range buttons "fixed" it because the click handler properly synced `currentRange`

## Test plan
- [ ] Open dashboard, switch to Activity tab — verify data matches 24h range
- [ ] Toggle to 7d and back to 24h — verify consistent behavior
- [ ] Existing dashboard tests pass (16/16 ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)