### PR TITLE
feat(#90): add periodic status notifications for long-running sessions

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,7 @@ export interface GatewayDefaults {
   disallowedTools: string[];
   maxTurnsPerAgent: number;
   agentTimeoutMs: number;
+  stuckNotifyMs: number;
   httpPort: number | false;
   logLevel: LogLevel;
 }
@@ -154,6 +155,7 @@ export function loadConfig(raw: unknown): GatewayConfig {
       disallowedTools: defaultDisallowed,
       maxTurnsPerAgent: typeof defaults.maxTurnsPerAgent === 'number' ? defaults.maxTurnsPerAgent : 5,
       agentTimeoutMs: typeof defaults.agentTimeoutMs === 'number' ? defaults.agentTimeoutMs : 3 * 60 * 1000,
+      stuckNotifyMs: typeof defaults.stuckNotifyMs === 'number' ? defaults.stuckNotifyMs : 300_000,
       httpPort: defaults.httpPort === false ? false : (typeof defaults.httpPort === 'number' ? defaults.httpPort : 3100),
       logLevel: isValidLogLevel(defaults.logLevel) ? defaults.logLevel : 'info',
     },

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -314,6 +314,18 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
     }, 7_000);
     replyChannel.sendTyping().catch(() => {});
 
+    // Periodic status notifications for long-running worktree sessions (#90)
+    const stuckNotifyMs = config.defaults.stuckNotifyMs;
+    const isWorktreeSession = replyChannel.isThread();
+    const sendStartTime = Date.now();
+    let stuckNotifyInterval: ReturnType<typeof setInterval> | null = null;
+    if (stuckNotifyMs > 0 && isWorktreeSession) {
+      stuckNotifyInterval = setInterval(() => {
+        const elapsed = Math.floor((Date.now() - sendStartTime) / 60_000);
+        replyChannel.send(`⏳ Still working… (${elapsed}m elapsed)`).catch(() => {});
+      }, stuckNotifyMs);
+    }
+
     // Look up agents for the project (use parent channel ID for threads)
     const projectChannelId = parentId || resolved.channelId;
     const project = config.projects[projectChannelId];
@@ -469,6 +481,7 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
       );
     } finally {
       clearInterval(typingInterval);
+      if (stuckNotifyInterval) clearInterval(stuckNotifyInterval);
     }
   });
 


### PR DESCRIPTION
## Summary
- Adds periodic Discord status messages for long-running worktree sessions (Option 4 from #90)
- After `stuckNotifyMs` (default 5 min), posts `⏳ Still working… ({elapsed}m elapsed)` every interval
- New `stuckNotifyMs` config option in gateway defaults — set to `0` to disable
- Purely informational: no process killing, typing indicator continues alongside

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] All 72 existing tests pass (config: 39, discord: 33)
- [ ] Manual: trigger a long-running session (>5 min) and verify status message appears
- [ ] Manual: set `stuckNotifyMs: 0` and verify no notifications are sent

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)