### PR TITLE
feat(#97): add token usage intensity heatmap to timeline

### DIFF
--- a/src/activity-engine.ts
+++ b/src/activity-engine.ts
@@ -111,6 +111,8 @@ export interface ActivityEngine {
       start: string;
       end: string;
       state: 'processing' | 'idle';
+      token_count?: number;
+      token_rate?: number;
     }>;
   }>;
 }
@@ -237,6 +239,16 @@ export function createActivityEngine(filePath?: string): ActivityEngine {
       const TIMELINE_TYPES = new Set(['session_start', 'message_routed', 'message_completed', 'session_end', 'session_idle']);
       const relevant = events.filter(e => TIMELINE_TYPES.has(e.event_type));
 
+      // Collect message_completed events indexed by session for token enrichment
+      const completedBySession = new Map<string, PulseEvent[]>();
+      for (const e of events) {
+        if (e.event_type === 'message_completed') {
+          const list = completedBySession.get(e.session_id);
+          if (list) list.push(e);
+          else completedBySession.set(e.session_id, [e]);
+        }
+      }
+
       // Group by session_id
       const sessionMap = new Map<string, PulseEvent[]>();
       for (const e of relevant) {
@@ -245,10 +257,11 @@ export function createActivityEngine(filePath?: string): ActivityEngine {
         else sessionMap.set(e.session_id, [e]);
       }
 
+      type Segment = { start: string; end: string; state: 'processing' | 'idle'; token_count?: number; token_rate?: number };
       const result: Array<{
         session_id: string;
         label: string;
-        segments: Array<{ start: string; end: string; state: 'processing' | 'idle' }>;
+        segments: Segment[];
       }> = [];
 
       for (const [sessionId, sessionEvents] of sessionMap) {
@@ -271,7 +284,7 @@ export function createActivityEngine(filePath?: string): ActivityEngine {
         const label = `mpg/${shortId}/${persona}`;
 
         // Build segments by walking through events
-        const segments: Array<{ start: string; end: string; state: 'processing' | 'idle' }> = [];
+        const segments: Segment[] = [];
         let currentState: 'processing' | 'idle' = 'idle';
         let segmentStart = sessionEvents[0].timestamp;
 
@@ -304,6 +317,26 @@ export function createActivityEngine(filePath?: string): ActivityEngine {
               segments.push({ start: segmentStart, end: lastEvent.timestamp, state: currentState });
             }
           }
+        }
+
+        // Enrich processing segments with token data
+        const completed = completedBySession.get(sessionId) || [];
+        for (const seg of segments) {
+          if (seg.state !== 'processing') continue;
+          const segStartMs = new Date(seg.start).getTime();
+          const segEndMs = new Date(seg.end).getTime();
+          const durationSec = (segEndMs - segStartMs) / 1000;
+
+          let tokenCount = 0;
+          for (const ev of completed) {
+            const evMs = new Date(ev.timestamp).getTime();
+            if (evMs >= segStartMs && evMs <= segEndMs) {
+              tokenCount += (Number(ev.input_tokens) || 0) + (Number(ev.output_tokens) || 0);
+            }
+          }
+
+          seg.token_count = tokenCount;
+          seg.token_rate = durationSec > 0 ? Math.round(tokenCount / durationSec) : 0;
         }
 
         result.push({ session_id: sessionId, label, segments });

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -391,7 +391,8 @@ function refreshTimeline() {
         return;
       }
 
-      var totalH = HEADER_H + activeSessions.length * ROW_H + FOOTER_H;
+      var LEGEND_H = 28;
+      var totalH = HEADER_H + activeSessions.length * ROW_H + FOOTER_H + LEGEND_H;
       canvas.width = Math.floor(chartW * dpr);
       canvas.height = Math.floor(totalH * dpr);
       canvas.style.width = chartW + 'px';
@@ -434,6 +435,26 @@ function refreshTimeline() {
 
       _tlHitRects = [];
 
+      // Compute maxTokenRate across all visible processing segments for normalization
+      var maxTokenRate = 0;
+      for (var mi = 0; mi < activeSessions.length; mi++) {
+        for (var mj = 0; mj < activeSessions[mi].segments.length; mj++) {
+          var mseg = activeSessions[mi].segments[mj];
+          if (mseg.state === 'processing' && mseg.token_rate > maxTokenRate) {
+            maxTokenRate = mseg.token_rate;
+          }
+        }
+      }
+
+      function tokenRateColor(rate) {
+        if (!maxTokenRate || !rate) return 'hsl(130, 30%, 55%)';
+        var t = Math.min(rate / maxTokenRate, 1);
+        // Interpolate: low rate → light/desaturated green, high rate → dark/saturated green
+        var sat = 30 + t * 50;   // 30% → 80%
+        var light = 55 - t * 25; // 55% → 30%
+        return 'hsl(130, ' + sat + '%, ' + light + '%)';
+      }
+
       for (var ri = 0; ri < activeSessions.length; ri++) {
         var sess = activeSessions[ri];
         var rowY = HEADER_H + ri * ROW_H;
@@ -465,11 +486,41 @@ function refreshTimeline() {
           var x2 = timeToX(segEnd);
           var w = Math.max(x2 - x1, 1);
 
-          ctx.fillStyle = seg.state === 'processing' ? '#3fb950' : '#484f58';
+          ctx.fillStyle = seg.state === 'processing' ? tokenRateColor(seg.token_rate || 0) : '#484f58';
           ctx.fillRect(x1, barY, w, barH);
 
-          _tlHitRects.push({ x: x1, y: barY, w: w, h: barH, label: sess.label, state: seg.state, start: seg.start, end: seg.end });
+          _tlHitRects.push({ x: x1, y: barY, w: w, h: barH, label: sess.label, state: seg.state, start: seg.start, end: seg.end, token_count: seg.token_count || 0, token_rate: seg.token_rate || 0 });
         }
+      }
+
+      // Draw intensity legend below the chart
+      if (maxTokenRate > 0) {
+        var lgX = plotLeft;
+        var lgY = totalH - LEGEND_H + 4;
+        var lgW = 120;
+        var lgH = 10;
+
+        ctx.fillStyle = '#8b949e';
+        ctx.font = '10px -apple-system, sans-serif';
+        ctx.textAlign = 'left';
+        ctx.fillText('Token rate:', lgX, lgY + 9);
+
+        var gradX = lgX + 68;
+        // Draw gradient bar
+        for (var gi = 0; gi < lgW; gi++) {
+          var gt = gi / lgW;
+          var gSat = 30 + gt * 50;
+          var gLight = 55 - gt * 25;
+          ctx.fillStyle = 'hsl(130, ' + gSat + '%, ' + gLight + '%)';
+          ctx.fillRect(gradX + gi, lgY + 1, 1, lgH);
+        }
+
+        ctx.fillStyle = '#8b949e';
+        ctx.font = '9px -apple-system, sans-serif';
+        ctx.textAlign = 'left';
+        ctx.fillText('0', gradX, lgY + 22);
+        ctx.textAlign = 'right';
+        ctx.fillText(compactTokens(maxTokenRate) + '/s', gradX + lgW, lgY + 22);
       }
     })
     .catch(function(err) { console.error('Timeline fetch error:', err); });
@@ -491,7 +542,11 @@ function refreshTimeline() {
     }
     if (hit) {
       var state = hit.state.charAt(0).toUpperCase() + hit.state.slice(1);
-      tooltip.innerHTML = '<strong>' + hit.label + '</strong><br>' + state + ': ' + formatSegmentDuration(hit.start, hit.end);
+      var tokenInfo = '';
+      if (hit.state === 'processing' && hit.token_count > 0) {
+        tokenInfo = '<br>Tokens: ' + compactTokens(hit.token_count) + ' (' + compactTokens(hit.token_rate) + ' tok/s)';
+      }
+      tooltip.innerHTML = '<strong>' + hit.label + '</strong><br>' + state + ': ' + formatSegmentDuration(hit.start, hit.end) + tokenInfo;
       tooltip.style.display = 'block';
       tooltip.style.left = (e.clientX + 12) + 'px';
       tooltip.style.top = (e.clientY - 10) + 'px';

--- a/tests/activity-engine.test.ts
+++ b/tests/activity-engine.test.ts
@@ -253,11 +253,13 @@ describe('ActivityEngine', () => {
         end: t1.toISOString(),
         state: 'idle',
       });
-      // processing: message_routed → message_completed
+      // processing: message_routed → message_completed (with token enrichment)
       expect(timeline[0].segments[1]).toEqual({
         start: t1.toISOString(),
         end: t2.toISOString(),
         state: 'processing',
+        token_count: 0,
+        token_rate: 0,
       });
       // idle: message_completed → session_end
       expect(timeline[0].segments[2]).toEqual({
@@ -381,6 +383,42 @@ describe('ActivityEngine', () => {
       expect(timeline[0].segments[0].state).toBe('idle');
       expect(timeline[0].segments[1].state).toBe('processing');
       expect(timeline[0].segments[1].end).toBe(t2.toISOString());
+    });
+
+    it('enriches processing segments with token_count and token_rate', () => {
+      const t0 = new Date('2026-03-29T10:00:00Z');
+      const t1 = new Date('2026-03-29T10:01:00Z'); // routed
+      const t2 = new Date('2026-03-29T10:05:00Z'); // completed (4 min = 240s processing)
+      const t3 = new Date('2026-03-29T10:06:00Z'); // session end
+      writeEvents(filePath, [
+        makeEvent({ event_type: 'session_start', session_id: 'sess-tok00000', timestamp: t0.toISOString(), agent_name: 'engineer' }),
+        makeEvent({ event_type: 'message_routed', session_id: 'sess-tok00000', timestamp: t1.toISOString(), agent_target: 'engineer' }),
+        makeEvent({ event_type: 'message_completed', session_id: 'sess-tok00000', timestamp: t2.toISOString(), input_tokens: 5000, output_tokens: 3000 }),
+        makeEvent({ event_type: 'session_end', session_id: 'sess-tok00000', timestamp: t3.toISOString() }),
+      ]);
+      const engine = createActivityEngine(filePath);
+      const timeline = engine.sessionTimeline('7d');
+      expect(timeline).toHaveLength(1);
+      const processingSegment = timeline[0].segments.find(s => s.state === 'processing');
+      expect(processingSegment).toBeDefined();
+      // 5000 + 3000 = 8000 tokens over 240 seconds = 33 tok/s (rounded)
+      expect(processingSegment!.token_count).toBe(8000);
+      expect(processingSegment!.token_rate).toBe(Math.round(8000 / 240));
+    });
+
+    it('idle segments have no token fields', () => {
+      const t0 = new Date('2026-03-29T10:00:00Z');
+      const t1 = new Date('2026-03-29T10:01:00Z');
+      writeEvents(filePath, [
+        makeEvent({ event_type: 'session_start', session_id: 'sess-idl00000', timestamp: t0.toISOString() }),
+        makeEvent({ event_type: 'session_end', session_id: 'sess-idl00000', timestamp: t1.toISOString() }),
+      ]);
+      const engine = createActivityEngine(filePath);
+      const timeline = engine.sessionTimeline('7d');
+      const idleSegment = timeline[0].segments[0];
+      expect(idleSegment.state).toBe('idle');
+      expect(idleSegment.token_count).toBeUndefined();
+      expect(idleSegment.token_rate).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #97

- **Backend** (`activity-engine.ts`): Enrich each processing segment with `token_count` (input + output tokens from `message_completed` events within the segment's time range) and `token_rate` (tokens per second). Idle segments are unchanged.
- **Frontend** (`dashboard-server.ts`): Map `token_rate` to HSL-based color intensity (light green → dark saturated green), update tooltip to show `Tokens: X (Y tok/s)` for processing segments, and render a gradient legend with min/max labels below the chart.
- **Tests** (`activity-engine.test.ts`): 2 new tests for token enrichment and idle segment exclusion, 1 updated existing test for new fields. All 377 tests pass.

## Test plan
- [ ] Verify processing segments with higher token throughput appear darker/more saturated green
- [ ] Verify idle segments remain gray
- [ ] Hover over processing segment — tooltip shows token count and rate
- [ ] Legend gradient visible below chart with accurate min/max labels
- [ ] Switch between 24h/7d/30d ranges — no performance regression
- [ ] `npm test` — 377/377 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)