### PR TITLE
fix(#108): resolve actual project name in timeline labels

### DIFF
--- a/src/activity-engine.ts
+++ b/src/activity-engine.ts
@@ -108,7 +108,7 @@ export interface ActivityEngine {
     cache_read_tokens: number;
     cache_hit_ratio: number;
   };
-  sessionTimeline(range: TimeRange): Array<{
+  sessionTimeline(range: TimeRange, projectNameMap?: Record<string, string>): Array<{
     session_id: string;
     label: string;
     segments: Array<{
@@ -238,7 +238,7 @@ export function createActivityEngine(filePath?: string): ActivityEngine {
       };
     },
 
-    sessionTimeline(range) {
+    sessionTimeline(range, projectNameMap) {
       const events = readEvents(target, range);
       const TIMELINE_TYPES = new Set(['session_start', 'message_routed', 'message_completed', 'session_end', 'session_idle']);
       const relevant = events.filter(e => TIMELINE_TYPES.has(e.event_type));
@@ -285,7 +285,12 @@ export function createActivityEngine(filePath?: string): ActivityEngine {
         }
 
         const shortId = sessionId.substring(0, 8);
-        const label = `mpg/${shortId}/${persona}`;
+        // Resolve project name from the event's project_key via the config map
+        const projectKey = sessionEvents[0].project_key;
+        // project_key may be "channelId" or "channelId:agentName"; extract the channel part
+        const channelId = projectKey?.includes(':') ? projectKey.split(':')[0] : projectKey;
+        const projectName = (projectNameMap && channelId ? projectNameMap[channelId] : undefined) ?? 'mpg';
+        const label = `${projectName}/${shortId}/${persona}`;
 
         // Build segments by walking through events
         const segments: Segment[] = [];

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -796,7 +796,13 @@ export function createDashboardServer(
         return;
       }
       try {
-        const data = engine.sessionTimeline(rangeParam as TimeRange);
+        const projectNameMap: Record<string, string> = {};
+        if (config) {
+          for (const [channelId, project] of Object.entries(config.projects)) {
+            projectNameMap[channelId] = project.name;
+          }
+        }
+        const data = engine.sessionTimeline(rangeParam as TimeRange, projectNameMap);
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify(data));
       } catch {

--- a/tests/activity-engine.test.ts
+++ b/tests/activity-engine.test.ts
@@ -339,6 +339,30 @@ describe('ActivityEngine', () => {
       expect(timeline[0].label).toBe('mpg/sess-bar/default');
     });
 
+    it('resolves project name from projectNameMap', () => {
+      const t0 = new Date('2026-03-29T10:00:00Z');
+      const t1 = new Date('2026-03-29T10:01:00Z');
+      writeEvents(filePath, [
+        makeEvent({ event_type: 'session_start', session_id: 'sess-proj0000', timestamp: t0.toISOString(), project_key: '123456789', agent_name: 'engineer' }),
+        makeEvent({ event_type: 'session_end', session_id: 'sess-proj0000', timestamp: t1.toISOString(), project_key: '123456789' }),
+      ]);
+      const engine = createActivityEngine(filePath);
+      const timeline = engine.sessionTimeline('7d', { '123456789': 'my-cool-project' });
+      expect(timeline[0].label).toBe('my-cool-project/sess-pro/engineer');
+    });
+
+    it('resolves project name when project_key contains agent suffix', () => {
+      const t0 = new Date('2026-03-29T10:00:00Z');
+      const t1 = new Date('2026-03-29T10:01:00Z');
+      writeEvents(filePath, [
+        makeEvent({ event_type: 'session_start', session_id: 'sess-agt00000', timestamp: t0.toISOString(), project_key: '123456789:engineer', agent_name: 'engineer' }),
+        makeEvent({ event_type: 'session_end', session_id: 'sess-agt00000', timestamp: t1.toISOString(), project_key: '123456789:engineer' }),
+      ]);
+      const engine = createActivityEngine(filePath);
+      const timeline = engine.sessionTimeline('7d', { '123456789': 'my-cool-project' });
+      expect(timeline[0].label).toBe('my-cool-project/sess-agt/engineer');
+    });
+
     it('handles session_idle as session end', () => {
       const t0 = new Date('2026-03-29T10:00:00Z');
       const t1 = new Date('2026-03-29T10:05:00Z');

--- a/tests/dashboard-server.test.ts
+++ b/tests/dashboard-server.test.ts
@@ -368,7 +368,7 @@ describe('createDashboardServer', () => {
       expect(body).toHaveLength(1);
       expect(body[0].label).toBe('mpg/sess-123/engineer');
       expect(body[0].segments).toHaveLength(2);
-      expect(engine.sessionTimeline).toHaveBeenCalledWith('24h');
+      expect(engine.sessionTimeline).toHaveBeenCalledWith('24h', { 'ch-1': 'My Project', 'ch-2': 'Other Project' });
     });
 
     it('returns empty array when no engine provided', async () => {
@@ -387,7 +387,7 @@ describe('createDashboardServer', () => {
       });
       const res = await httpGet(port, '/api/activity/timeline?range=3h');
       expect(res.status).toBe(200);
-      expect(engine.sessionTimeline).toHaveBeenCalledWith('3h');
+      expect(engine.sessionTimeline).toHaveBeenCalledWith('3h', { 'ch-1': 'My Project', 'ch-2': 'Other Project' });
     });
 
     it('accepts 12h range and passes it to engine', async () => {
@@ -398,7 +398,7 @@ describe('createDashboardServer', () => {
       });
       const res = await httpGet(port, '/api/activity/timeline?range=12h');
       expect(res.status).toBe(200);
-      expect(engine.sessionTimeline).toHaveBeenCalledWith('12h');
+      expect(engine.sessionTimeline).toHaveBeenCalledWith('12h', { 'ch-1': 'My Project', 'ch-2': 'Other Project' });
     });
 
     it('returns 400 for invalid range', async () => {


### PR DESCRIPTION
## Summary
- Timeline labels were hardcoded as `mpg/...` for all sessions regardless of actual project
- `sessionTimeline()` now accepts a project name map to resolve channel IDs to configured project names
- Falls back to `mpg` when no map or no matching project is found

Closes #108

## Test plan
- [x] Existing timeline tests pass (label falls back to `mpg` when no map provided)
- [x] New test: project name resolved from map
- [x] New test: project name resolved when `project_key` contains `:agent` suffix
- [x] Dashboard server tests updated to verify map is passed through

🤖 Generated with [Claude Code](https://claude.com/claude-code)