### PR TITLE
feat(#112): startup recovery for orphaned tmux sessions

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -214,6 +214,15 @@ function start() {
           log.warn(`Dashboard server failed to start on port ${config.defaults.httpPort}: ${err}`);
         }
       }
+
+      // Recover orphaned tmux sessions after Discord is connected
+      sessionManager.recoverOrphanedSessions((projectKey, result) => {
+        bot.deliverOrphanResult(projectKey, result).catch((err) => {
+          log.error(`Failed to deliver orphan result for ${projectKey}: ${err}`);
+        });
+      }).catch((err) => {
+        log.error(`Orphan session recovery failed: ${err}`);
+      });
     })
     .catch((err) => {
       log.error(`Failed to start bot: ${err}`);

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -48,6 +48,8 @@ export interface DiscordBot {
   start(token: string): Promise<void>;
   stop(): void;
   getStatus(): string;
+  /** Deliver an orphaned session result to the appropriate Discord thread. */
+  deliverOrphanResult(projectKey: string, result: import('./claude-cli.js').ClaudeResult): Promise<void>;
 }
 
 function resolveProjectName(config: GatewayConfig, channelId: string): string {
@@ -508,6 +510,31 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
         [Status.Resuming]: 'resuming',
       };
       return statusMap[ws.status] ?? 'unknown';
+    },
+    async deliverOrphanResult(projectKey: string, result: import('./claude-cli.js').ClaudeResult): Promise<void> {
+      // projectKey is "threadId" or "threadId:agentName"
+      const threadId = projectKey.includes(':') ? projectKey.split(':')[0] : projectKey;
+      const agentName = projectKey.includes(':') ? projectKey.split(':').pop() : undefined;
+
+      try {
+        const channel = await client.channels.fetch(threadId);
+        if (!channel || !('send' in channel)) {
+          console.error(`Cannot deliver orphan result: channel ${threadId} not found or not sendable`);
+          return;
+        }
+
+        // Look up agent role if this was an agent session
+        let agentRole: string | undefined;
+        if (agentName && channel.isThread() && channel.parentId) {
+          const project = config.projects[channel.parentId];
+          agentRole = project?.agents?.[agentName]?.role;
+        }
+
+        await channel.send('🔄 Resumed after gateway restart — here is the pending response:');
+        await sendAgentMessage(channel as TextChannel | ThreadChannel, result.text, agentName, agentRole);
+      } catch (err) {
+        console.error(`Failed to deliver orphan result to ${threadId}:`, err);
+      }
     },
   };
 }

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -14,6 +14,9 @@ export interface SessionInfo {
   processing: boolean;
 }
 
+/** Callback invoked when an orphaned tmux session produces a result on startup recovery. */
+export type OrphanResultCallback = (projectKey: string, result: ClaudeResult) => void;
+
 export interface SessionManager {
   send(projectKey: string, cwd: string, prompt: string, opts?: { worktree?: boolean; systemPrompt?: string; timeoutMs?: number; extraArgs?: string[] }): Promise<ClaudeResult>;
   getSession(projectKey: string): SessionInfo | undefined;
@@ -21,6 +24,8 @@ export interface SessionManager {
   clearSession(projectKey: string): boolean;
   restartSession(projectKey: string): boolean;
   shutdown(): void;
+  /** Discover orphaned tmux sessions and reattach to them. Call after Discord bot is ready. */
+  recoverOrphanedSessions(onResult: OrphanResultCallback): Promise<void>;
 }
 
 interface InternalSession {
@@ -407,6 +412,61 @@ export function createSessionManager(defaults: {
       resetIdleTimer(session);
       persistSessions();
       return true;
+    },
+
+    async recoverOrphanedSessions(onResult: OrphanResultCallback): Promise<void> {
+      if (!runtime.canResume) return;
+
+      let orphanedKeys: string[];
+      try {
+        orphanedKeys = await runtime.listOrphanedSessions();
+      } catch (err) {
+        console.error('Failed to list orphaned sessions:', err);
+        return;
+      }
+      if (orphanedKeys.length === 0) return;
+
+      console.log(`Discovered ${orphanedKeys.length} orphaned tmux session(s)`);
+
+      // Cross-reference with persisted sessions
+      const persisted = store ? store.load() : new Map<string, PersistedSession>();
+
+      const reattachPromises: Promise<void>[] = [];
+
+      for (const key of orphanedKeys) {
+        const entry = persisted.get(key);
+        if (!entry) {
+          // No persisted record — stale orphan, clean it up
+          console.log(`Cleaning up unmatched orphan: ${key}`);
+          if (runtime.cleanup) runtime.cleanup(key);
+          continue;
+        }
+
+        // Matched — reattach and deliver result
+        reattachPromises.push(
+          (async () => {
+            try {
+              if (pulseEmitter) {
+                pulseEmitter.sessionResume(
+                  entry.sessionId,
+                  entry.projectKey,
+                  entry.cwd,
+                  Date.now() - entry.lastActivity,
+                );
+              }
+              const result = await runtime.reattach(key);
+              console.log(`Reattached orphan ${key}: ${result.text.length} chars`);
+              onResult(entry.projectKey, result);
+            } catch (err) {
+              console.error(`Failed to reattach orphan ${key}:`, err);
+            } finally {
+              if (runtime.cleanup) runtime.cleanup(key);
+            }
+          })(),
+        );
+      }
+
+      await Promise.all(reattachPromises);
     },
 
     shutdown() {

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -26,6 +26,26 @@ function createMockRuntime(): AgentRuntime & { spawn: ReturnType<typeof vi.fn<(o
   };
 }
 
+/** Mock runtime with canResume=true and spyable reattach/listOrphanedSessions/cleanup. */
+function createResumableRuntime() {
+  return {
+    name: 'mock-tmux',
+    canResume: true,
+    spawn: vi.fn<(opts: SpawnOpts) => Promise<ClaudeResult>>().mockResolvedValue({
+      text: 'Mock response',
+      sessionId: 'mock-session-id',
+      isError: false,
+    }),
+    listOrphanedSessions: vi.fn<() => Promise<string[]>>().mockResolvedValue([]),
+    reattach: vi.fn<(key: string) => Promise<ClaudeResult>>().mockResolvedValue({
+      text: 'Reattached response',
+      sessionId: 'reattached-sid',
+      isError: false,
+    }),
+    cleanup: vi.fn(),
+  };
+}
+
 const defaults = {
   idleTimeoutMs: 500,
   maxConcurrentSessions: 2,
@@ -556,6 +576,108 @@ describe('SessionManager', () => {
       await m.send('new-proj', '/tmp/new', 'Hello');
       expect(store.saved!.has('old-proj')).toBe(false);
       expect(store.saved!.has('new-proj')).toBe(true);
+      m.shutdown();
+    });
+  });
+
+  describe('orphan session recovery', () => {
+    it('skips recovery when runtime does not support resume', async () => {
+      const rt = createMockRuntime(); // canResume=false
+      const m = createSessionManager(defaults, rt);
+      const onResult = vi.fn();
+      await m.recoverOrphanedSessions(onResult);
+      expect(onResult).not.toHaveBeenCalled();
+      m.shutdown();
+    });
+
+    it('cleans up unmatched orphan sessions (no persisted record)', async () => {
+      const rt = createResumableRuntime();
+      rt.listOrphanedSessions.mockResolvedValue(['unknown-key']);
+      const store = createMockStore(); // empty — no persisted sessions
+      const m = createSessionManager(defaults, rt, store);
+      const onResult = vi.fn();
+      await m.recoverOrphanedSessions(onResult);
+      expect(rt.cleanup).toHaveBeenCalledWith('unknown-key');
+      expect(rt.reattach).not.toHaveBeenCalled();
+      expect(onResult).not.toHaveBeenCalled();
+      m.shutdown();
+    });
+
+    it('reattaches matched orphan sessions and delivers result', async () => {
+      const rt = createResumableRuntime();
+      rt.listOrphanedSessions.mockResolvedValue(['thread-123']);
+      rt.reattach.mockResolvedValue({ text: 'Orphan output', sessionId: 'orphan-sid', isError: false });
+      const store = createMockStore([
+        { sessionId: 'old-sid', projectKey: 'thread-123', cwd: '/tmp/proj', lastActivity: Date.now() - 5000 },
+      ]);
+      const m = createSessionManager(defaults, rt, store);
+      const onResult = vi.fn();
+      await m.recoverOrphanedSessions(onResult);
+      expect(rt.reattach).toHaveBeenCalledWith('thread-123');
+      expect(onResult).toHaveBeenCalledWith('thread-123', expect.objectContaining({ text: 'Orphan output' }));
+      expect(rt.cleanup).toHaveBeenCalledWith('thread-123');
+      m.shutdown();
+    });
+
+    it('emits session_resume for reattached orphans', async () => {
+      const rt = createResumableRuntime();
+      rt.listOrphanedSessions.mockResolvedValue(['thread-456']);
+      const store = createMockStore([
+        { sessionId: 'sid-456', projectKey: 'thread-456', cwd: '/tmp/proj', lastActivity: Date.now() - 10000 },
+      ]);
+      const pulseEmitter = {
+        sessionStart: vi.fn(),
+        sessionEnd: vi.fn(),
+        sessionIdle: vi.fn(),
+        sessionResume: vi.fn(),
+        messageRouted: vi.fn(),
+        messageCompleted: vi.fn(),
+      };
+      const m = createSessionManager(defaults, rt, store, pulseEmitter);
+      await m.recoverOrphanedSessions(vi.fn());
+      expect(pulseEmitter.sessionResume).toHaveBeenCalledWith(
+        'sid-456', 'thread-456', '/tmp/proj', expect.any(Number),
+      );
+      m.shutdown();
+    });
+
+    it('handles reattach failure gracefully', async () => {
+      const rt = createResumableRuntime();
+      rt.listOrphanedSessions.mockResolvedValue(['thread-789']);
+      rt.reattach.mockRejectedValue(new Error('output file missing'));
+      const store = createMockStore([
+        { sessionId: 'sid-789', projectKey: 'thread-789', cwd: '/tmp/proj', lastActivity: Date.now() - 5000 },
+      ]);
+      const m = createSessionManager(defaults, rt, store);
+      const onResult = vi.fn();
+      // Should not throw
+      await m.recoverOrphanedSessions(onResult);
+      expect(onResult).not.toHaveBeenCalled();
+      expect(rt.cleanup).toHaveBeenCalledWith('thread-789');
+      m.shutdown();
+    });
+
+    it('processes multiple orphans concurrently', async () => {
+      const rt = createResumableRuntime();
+      rt.listOrphanedSessions.mockResolvedValue(['t-1', 't-2', 't-unknown']);
+      rt.reattach.mockImplementation(async (key: string) => ({
+        text: `Result for ${key}`,
+        sessionId: `sid-${key}`,
+        isError: false,
+      }));
+      const store = createMockStore([
+        { sessionId: 'old-1', projectKey: 't-1', cwd: '/tmp/a', lastActivity: Date.now() - 1000 },
+        { sessionId: 'old-2', projectKey: 't-2', cwd: '/tmp/b', lastActivity: Date.now() - 2000 },
+      ]);
+      const m = createSessionManager(defaults, rt, store);
+      const onResult = vi.fn();
+      await m.recoverOrphanedSessions(onResult);
+      // t-1 and t-2 reattached, t-unknown cleaned up
+      expect(rt.reattach).toHaveBeenCalledTimes(2);
+      expect(onResult).toHaveBeenCalledTimes(2);
+      expect(rt.cleanup).toHaveBeenCalledWith('t-unknown'); // unmatched
+      expect(rt.cleanup).toHaveBeenCalledWith('t-1'); // post-reattach
+      expect(rt.cleanup).toHaveBeenCalledWith('t-2'); // post-reattach
       m.shutdown();
     });
   });


### PR DESCRIPTION
## Summary
- Adds startup re-discovery and reattachment of orphaned tmux sessions that survived a gateway restart
- When mpg restarts with `persistence: "tmux"`, it discovers surviving tmux sessions, cross-references them against persisted records, and delivers completed results back to the originating Discord threads

## How it works
1. After Discord bot connects, `sessionManager.recoverOrphanedSessions()` is called
2. Calls `runtime.listOrphanedSessions()` to find surviving `mpg-*` tmux sessions
3. **Matched** (session key found in `.sessions.json`): calls `runtime.reattach(key)` to get result, delivers via `bot.deliverOrphanResult()` to the Discord thread, then cleans up
4. **Unmatched** (no persisted record): calls `runtime.cleanup(key)` to kill the stale orphan
5. All reattachments run concurrently via `Promise.all`

## Files changed
- **`src/session-manager.ts`**: Add `recoverOrphanedSessions(onResult)` method + `OrphanResultCallback` type
- **`src/discord.ts`**: Add `deliverOrphanResult(projectKey, result)` to `DiscordBot` interface — looks up thread by ID, sends recovery message with result
- **`src/cli.ts`**: Wire recovery after `bot.start()` resolves
- **`tests/session-manager.test.ts`**: 6 new tests for the recovery path

## Test plan
- [x] All 413 tests pass (407 existing + 6 new)
- [x] TypeScript compiles cleanly
- [x] Tests cover: skip when canResume=false, cleanup unmatched, reattach matched, pulse emission, error handling, concurrent processing
- [ ] Manual: start with `persistence: "tmux"`, send a message, kill mpg while Claude is running, restart mpg, verify result is delivered to Discord thread

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)