### PR TITLE
fix(#114): prevent zombie tmux sessions from accumulating

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { createFileSessionStore } from './session-store.js';
 import { ClaudeCliRuntime } from './runtimes/claude-cli-runtime.js';
 import { TmuxRuntime } from './runtimes/tmux-runtime.js';
 import type { AgentRuntime } from './agent-runtime.js';
+import { listSessions, killSession } from './tmux.js';
 import { createDiscordBot } from './discord.js';
 import { createPulseEmitter } from './pulse-events.js';
 import { createActivityEngine } from './activity-engine.js';
@@ -165,6 +166,19 @@ function start() {
     log.info('Using tmux-based persistent runtime');
   } else {
     runtime = new ClaudeCliRuntime();
+
+    // Sweep stale tmux sessions from a previous tmux-mode run
+    try {
+      const stale = listSessions('mpg-');
+      for (const name of stale) {
+        killSession(name);
+      }
+      if (stale.length > 0) {
+        log.info(`Cleaned up ${stale.length} stale tmux session(s)`);
+      }
+    } catch {
+      // tmux not installed — nothing to sweep
+    }
   }
   const sessionManager = createSessionManager(config.defaults, runtime, sessionStore, pulseEmitter);
 

--- a/src/runtimes/tmux-runtime.ts
+++ b/src/runtimes/tmux-runtime.ts
@@ -56,10 +56,13 @@ export class TmuxRuntime implements AgentRuntime {
     const outPath = outputFile(sessionKey);
     const errPath = stderrFile(sessionKey);
 
-    // Build the claude command
+    // Build the claude command, wrapped with `timeout` so the tmux session
+    // self-destructs if mpg never reads the output (prevents zombie sessions).
     const args = buildClaudeArgs(opts.baseArgs, opts.prompt, opts.sessionId, opts.systemPrompt);
     const escapedArgs = args.map((a) => shellEscape(a));
-    const command = `claude ${escapedArgs.join(' ')} > ${shellEscape(outPath)} 2> ${shellEscape(errPath)}`;
+    const bufferMs = 5 * 60 * 1000; // 5 minutes buffer beyond mpg's own timeout
+    const timeoutSec = Math.ceil((timeoutMs + bufferMs) / 1000);
+    const command = `timeout ${timeoutSec} claude ${escapedArgs.join(' ')} > ${shellEscape(outPath)} 2> ${shellEscape(errPath)}`;
 
     // Kill any stale session with the same name
     if (sessionExists(tmuxName)) {

--- a/tests/tmux-runtime.test.ts
+++ b/tests/tmux-runtime.test.ts
@@ -76,7 +76,7 @@ describe('TmuxRuntime', () => {
       timeoutMs: 5000,
     };
 
-    it('creates output directory and launches tmux session', async () => {
+    it('creates output directory and launches tmux session with timeout wrapper', async () => {
       // Session exits immediately, output file exists with valid JSON
       mockSessionExists.mockReturnValue(false);
       mockExistsSync.mockReturnValue(true);
@@ -95,6 +95,21 @@ describe('TmuxRuntime', () => {
       );
       expect(result.text).toBe('Hello from tmux');
       expect(result.sessionId).toBe('tmux-session-123');
+
+      // Verify timeout wrapper: timeoutMs=5000 + 5min buffer = 305s
+      const command = mockCreateSession.mock.calls[0][1] as string;
+      expect(command).toMatch(/^timeout 305 claude /);
+    });
+
+    it('uses default timeout (20min + 5min buffer = 1500s) when timeoutMs is omitted', async () => {
+      mockSessionExists.mockReturnValue(false);
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(validOutput);
+
+      await runtime.spawn({ ...spawnOpts, timeoutMs: undefined });
+
+      const command = mockCreateSession.mock.calls[0][1] as string;
+      expect(command).toMatch(/^timeout 1500 claude /);
     });
 
     it('kills stale tmux session before launching new one', async () => {


### PR DESCRIPTION
## Summary
- Wraps tmux spawn commands with `timeout` so sessions self-destruct if mpg never reads the output
- Sweeps stale `mpg-*` tmux sessions on startup when running in direct (non-tmux) mode

## Changes

### 1. Timeout wrapper (`src/runtimes/tmux-runtime.ts`)
The tmux session command is now:
```
timeout <seconds> claude ... > output.json 2> stderr.log
```
Where `<seconds>` = `timeoutMs + 5min buffer` (default: 1500s for 20min timeout). This ensures the tmux session terminates even if mpg crashes and never polls for the result.

### 2. Startup sweep (`src/cli.ts`)
When starting in `persistence: 'direct'` mode, any leftover `mpg-*` tmux sessions from a previous tmux-mode run are killed. Wrapped in try/catch so missing tmux doesn't block startup.

## Test plan
- [x] All 414 tests pass
- [x] TypeScript compiles cleanly
- [x] Test verifies `timeout 305` in command for 5s timeout (5000ms + 5min buffer)
- [x] Test verifies `timeout 1500` for default 20min timeout

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)