### PR TITLE
fix(#118): resolve dashboard project names from directory

### DIFF
--- a/src/activity-engine.ts
+++ b/src/activity-engine.ts
@@ -60,6 +60,17 @@ function bucketKey(timestamp: string, bucket: Bucket): string {
   return d.toISOString();
 }
 
+/** Resolve a project name from its directory path using a directory→name map.
+ *  Handles both exact matches and worktree subdirectory matches. */
+function resolveNameFromDir(projectDir: string, dirToNameMap?: Record<string, string>): string | undefined {
+  if (!dirToNameMap || !projectDir) return undefined;
+  if (dirToNameMap[projectDir]) return dirToNameMap[projectDir];
+  for (const [dir, name] of Object.entries(dirToNameMap)) {
+    if (projectDir.startsWith(dir + '/')) return name;
+  }
+  return undefined;
+}
+
 export interface ActivityEngine {
   computeSummary(range: TimeRange): {
     total_cost_usd: number;
@@ -69,9 +80,8 @@ export interface ActivityEngine {
     total_messages: number;
     avg_session_duration_ms: number;
   };
-  tokensByProject(range: TimeRange): Array<{
-    project_key: string;
-    project_dir: string;
+  tokensByProject(range: TimeRange, dirToNameMap?: Record<string, string>): Array<{
+    project_name: string;
     input_tokens: number;
     output_tokens: number;
     cache_read_input_tokens: number;
@@ -108,7 +118,7 @@ export interface ActivityEngine {
     cache_read_tokens: number;
     cache_hit_ratio: number;
   };
-  sessionTimeline(range: TimeRange, projectNameMap?: Record<string, string>): Array<{
+  sessionTimeline(range: TimeRange, projectNameMap?: Record<string, string>, dirToNameMap?: Record<string, string>): Array<{
     session_id: string;
     label: string;
     segments: Array<{
@@ -148,18 +158,18 @@ export function createActivityEngine(filePath?: string): ActivityEngine {
       };
     },
 
-    tokensByProject(range) {
+    tokensByProject(range, dirToNameMap) {
       const messages = getEvents(range, 'message_completed');
-      const map = new Map<string, { project_key: string; project_dir: string; input_tokens: number; output_tokens: number; cache_read_input_tokens: number; cost_usd: number; message_count: number }>();
+      const map = new Map<string, { project_name: string; input_tokens: number; output_tokens: number; cache_read_input_tokens: number; cost_usd: number; message_count: number }>();
       for (const e of messages) {
-        const key = e.project_key;
-        const row = map.get(key) ?? { project_key: key, project_dir: e.project_dir, input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cost_usd: 0, message_count: 0 };
+        const name = resolveNameFromDir(e.project_dir, dirToNameMap) ?? e.project_key;
+        const row = map.get(name) ?? { project_name: name, input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cost_usd: 0, message_count: 0 };
         row.input_tokens += Number(e.input_tokens) || 0;
         row.output_tokens += Number(e.output_tokens) || 0;
         row.cache_read_input_tokens += Number(e.cache_read_input_tokens) || 0;
         row.cost_usd += Number(e.total_cost_usd) || 0;
         row.message_count++;
-        map.set(key, row);
+        map.set(name, row);
       }
       return Array.from(map.values());
     },
@@ -252,7 +262,7 @@ export function createActivityEngine(filePath?: string): ActivityEngine {
       };
     },
 
-    sessionTimeline(range, projectNameMap) {
+    sessionTimeline(range, projectNameMap, dirToNameMap) {
       const events = readEvents(target, range);
       const TIMELINE_TYPES = new Set(['session_start', 'message_routed', 'message_completed', 'session_end', 'session_idle']);
       const relevant = events.filter(e => TIMELINE_TYPES.has(e.event_type));
@@ -299,11 +309,13 @@ export function createActivityEngine(filePath?: string): ActivityEngine {
         }
 
         const shortId = sessionId.substring(0, 8);
-        // Resolve project name from the event's project_key via the config map
+        // Resolve project name: try directory-based lookup first, then channel ID, then fallback
+        const projectDir = sessionEvents[0].project_dir;
         const projectKey = sessionEvents[0].project_key;
-        // project_key may be "channelId" or "channelId:agentName"; extract the channel part
         const channelId = projectKey?.includes(':') ? projectKey.split(':')[0] : projectKey;
-        const projectName = (projectNameMap && channelId ? projectNameMap[channelId] : undefined) ?? 'mpg';
+        const projectName = resolveNameFromDir(projectDir, dirToNameMap)
+          ?? (projectNameMap && channelId ? projectNameMap[channelId] : undefined)
+          ?? 'unknown';
         const label = `${projectName}/${shortId}/${persona}`;
 
         // Build segments by walking through events

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -204,6 +204,15 @@ function resolveProjectName(key, nameMap) {
   var name = (nameMap && nameMap[channelId]) ? nameMap[channelId] : channelId;
   return agent ? name + ':' + agent : name;
 }
+function resolveProjectNameFromDir(dir, dirMap) {
+  if (!dir || !dirMap) return null;
+  if (dirMap[dir]) return dirMap[dir];
+  var keys = Object.keys(dirMap);
+  for (var i = 0; i < keys.length; i++) {
+    if (dir.indexOf(keys[i] + '/') === 0) return dirMap[keys[i]];
+  }
+  return null;
+}
 function copyToClipboard(text, el) {
   navigator.clipboard.writeText(text).then(function() {
     var orig = el.textContent;
@@ -230,10 +239,12 @@ function refresh() {
       discordEl.textContent = d.health.discord;
       discordEl.className = 'card-value ' + statusClass(d.health.discord);
 
-      // Build name map from projects list
+      // Build name maps from projects list
+      var dirToNameMap = {};
       if (d.projects) {
         d.projects.forEach(function(p) {
           if (p.channelId && p.name) projectNameMap[p.channelId] = p.name;
+          if (p.directory && p.name) dirToNameMap[p.directory] = p.name;
         });
       }
 
@@ -251,7 +262,7 @@ function refresh() {
           var sid = s.sessionId || '';
           var shortId = sid ? sid.slice(0, 8) : '';
           var pkParts = (s.projectKey || '').split(':');
-          var projName = (projectNameMap && projectNameMap[pkParts[0]]) ? projectNameMap[pkParts[0]] : pkParts[0];
+          var projName = resolveProjectNameFromDir(s.projectDir || s.cwd, dirToNameMap) || (projectNameMap && projectNameMap[pkParts[0]] ? projectNameMap[pkParts[0]] : null) || pkParts[0];
           var role = pkParts.length > 1 ? pkParts[1] : '';
           var sessionLabel = projName && shortId ? (role ? projName + '/' + shortId + '/' + role : projName + '/' + shortId) : (shortId || '—');
           h += '<tr><td><span class="clickable-id" style="cursor:pointer;text-decoration:underline dotted" title="Click to copy: ' + escapeHtml(sid) + '" onclick="copyToClipboard(\\'' + escapeHtml(sid) + '\\', this)">' + escapeHtml(sessionLabel) + '</span></td><td>' + sessionStatus(s) + '</td><td>' + formatDuration(s.createdAt) + '</td><td>' + formatAgo(s.lastActivity) + '</td></tr>';
@@ -669,7 +680,7 @@ function refreshActivity() {
       if (d.tokens_by_project.length === 0) { pt.innerHTML = '<div class="empty">No data</div>'; }
       else {
         var h = '<table><tr><th>Project</th><th>Input</th><th>Output</th><th>Cache Read</th><th>Cost</th><th>Messages</th></tr>';
-        d.tokens_by_project.forEach(function(p) { h += '<tr><td>' + escapeHtml(resolveProjectName(p.project_key, nameMap)) + '</td><td>' + compactTokens(p.input_tokens) + '</td><td>' + compactTokens(p.output_tokens) + '</td><td>' + compactTokens(p.cache_read_input_tokens) + '</td><td>$' + p.cost_usd.toFixed(3) + '</td><td>' + p.message_count + '</td></tr>'; });
+        d.tokens_by_project.forEach(function(p) { h += '<tr><td>' + escapeHtml(p.project_name || 'unknown') + '</td><td>' + compactTokens(p.input_tokens) + '</td><td>' + compactTokens(p.output_tokens) + '</td><td>' + compactTokens(p.cache_read_input_tokens) + '</td><td>$' + p.cost_usd.toFixed(3) + '</td><td>' + p.message_count + '</td></tr>'; });
         pt.innerHTML = h + '</table>';
       }
 
@@ -797,12 +808,14 @@ export function createDashboardServer(
       }
       try {
         const projectNameMap: Record<string, string> = {};
+        const dirToNameMap: Record<string, string> = {};
         if (config) {
           for (const [channelId, project] of Object.entries(config.projects)) {
             projectNameMap[channelId] = project.name;
+            dirToNameMap[project.directory] = project.name;
           }
         }
-        const data = engine.sessionTimeline(rangeParam as TimeRange, projectNameMap);
+        const data = engine.sessionTimeline(rangeParam as TimeRange, projectNameMap, dirToNameMap);
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify(data));
       } catch {
@@ -834,6 +847,7 @@ export function createDashboardServer(
           session_durations: [], model_breakdown: [], persona_breakdown: [],
           cache_efficiency: { total_input_tokens: 0, cache_read_tokens: 0, cache_hit_ratio: 0 },
           project_name_map: {},
+          dir_to_name_map: {},
         }));
         return;
       }
@@ -841,15 +855,17 @@ export function createDashboardServer(
       try {
         // Build channel ID → project name map from config
         const projectNameMap: Record<string, string> = {};
+        const dirToNameMap: Record<string, string> = {};
         if (config) {
           for (const [channelId, project] of Object.entries(config.projects)) {
             projectNameMap[channelId] = project.name;
+            dirToNameMap[project.directory] = project.name;
           }
         }
 
         const data = {
           summary: engine.computeSummary(range),
-          tokens_by_project: engine.tokensByProject(range),
+          tokens_by_project: engine.tokensByProject(range, dirToNameMap),
           tokens_by_session: engine.tokensBySession(range),
           sessions_over_time: engine.bucketed(range, bucket, 'session_start'),
           messages_over_time: engine.bucketed(range, bucket, 'message_completed'),
@@ -862,6 +878,7 @@ export function createDashboardServer(
           persona_breakdown: engine.personaBreakdown(range),
           cache_efficiency: engine.cacheEfficiency(range),
           project_name_map: projectNameMap,
+          dir_to_name_map: dirToNameMap,
         };
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify(data));

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -9,6 +9,8 @@ import { cleanupAttachments } from './attachments.js';
 export interface SessionInfo {
   sessionId: string;
   projectKey: string;
+  cwd: string;
+  projectDir?: string;
   lastActivity: number;
   queueLength: number;
   createdAt: number;
@@ -367,6 +369,8 @@ export function createSessionManager(defaults: {
       return {
         sessionId: session.sessionId ?? '',
         projectKey: session.projectKey,
+        cwd: session.cwd,
+        projectDir: session.projectDir,
         lastActivity: session.lastActivity,
         queueLength: session.queue.length,
         createdAt: session.createdAt,
@@ -378,6 +382,8 @@ export function createSessionManager(defaults: {
       return Array.from(sessions.values()).map((s) => ({
         sessionId: s.sessionId ?? '',
         projectKey: s.projectKey,
+        cwd: s.cwd,
+        projectDir: s.projectDir,
         lastActivity: s.lastActivity,
         queueLength: s.queue.length,
         createdAt: s.createdAt,

--- a/tests/activity-engine.test.ts
+++ b/tests/activity-engine.test.ts
@@ -83,21 +83,51 @@ describe('ActivityEngine', () => {
   });
 
   describe('tokensByProject', () => {
-    it('groups message_completed events by project_key', () => {
+    it('groups by project_key when no dirToNameMap provided', () => {
       writeEvents(filePath, [
-        makeEvent({ event_type: 'message_completed', project_key: 'proj-a', input_tokens: 10000, output_tokens: 2000, cache_read_input_tokens: 5000, total_cost_usd: 0.03 }),
-        makeEvent({ event_type: 'message_completed', project_key: 'proj-a', input_tokens: 8000, output_tokens: 1500, cache_read_input_tokens: 3000, total_cost_usd: 0.02 }),
-        makeEvent({ event_type: 'message_completed', project_key: 'proj-b', input_tokens: 5000, output_tokens: 1000, cache_read_input_tokens: 2000, total_cost_usd: 0.01 }),
+        makeEvent({ event_type: 'message_completed', project_key: 'proj-a', project_dir: '/tmp/a', input_tokens: 10000, output_tokens: 2000, cache_read_input_tokens: 5000, total_cost_usd: 0.03 }),
+        makeEvent({ event_type: 'message_completed', project_key: 'proj-a', project_dir: '/tmp/a', input_tokens: 8000, output_tokens: 1500, cache_read_input_tokens: 3000, total_cost_usd: 0.02 }),
+        makeEvent({ event_type: 'message_completed', project_key: 'proj-b', project_dir: '/tmp/b', input_tokens: 5000, output_tokens: 1000, cache_read_input_tokens: 2000, total_cost_usd: 0.01 }),
       ]);
       const engine = createActivityEngine(filePath);
       const rows = engine.tokensByProject('7d');
       expect(rows).toHaveLength(2);
-      const a = rows.find(r => r.project_key === 'proj-a')!;
+      const a = rows.find(r => r.project_name === 'proj-a')!;
       expect(a.input_tokens).toBe(18000);
       expect(a.output_tokens).toBe(3500);
       expect(a.cache_read_input_tokens).toBe(8000);
       expect(a.cost_usd).toBeCloseTo(0.05);
       expect(a.message_count).toBe(2);
+    });
+
+    it('aggregates by resolved project name from dirToNameMap', () => {
+      writeEvents(filePath, [
+        makeEvent({ event_type: 'message_completed', project_key: 'chan-1:engineer', project_dir: '/home/user/my-project', input_tokens: 10000, output_tokens: 2000, cache_read_input_tokens: 0, total_cost_usd: 0.03 }),
+        makeEvent({ event_type: 'message_completed', project_key: 'chan-1:pm', project_dir: '/home/user/my-project', input_tokens: 5000, output_tokens: 1000, cache_read_input_tokens: 0, total_cost_usd: 0.01 }),
+        makeEvent({ event_type: 'message_completed', project_key: 'chan-2:engineer', project_dir: '/home/user/other-project', input_tokens: 3000, output_tokens: 500, cache_read_input_tokens: 0, total_cost_usd: 0.005 }),
+      ]);
+      const engine = createActivityEngine(filePath);
+      const dirMap = { '/home/user/my-project': 'cool-project', '/home/user/other-project': 'other-project' };
+      const rows = engine.tokensByProject('7d', dirMap);
+      expect(rows).toHaveLength(2);
+      const cool = rows.find(r => r.project_name === 'cool-project')!;
+      expect(cool.input_tokens).toBe(15000);
+      expect(cool.output_tokens).toBe(3000);
+      expect(cool.cost_usd).toBeCloseTo(0.04);
+      expect(cool.message_count).toBe(2);
+    });
+
+    it('resolves worktree subdirectories via dirToNameMap', () => {
+      writeEvents(filePath, [
+        makeEvent({ event_type: 'message_completed', project_key: 'chan-1:engineer', project_dir: '/home/user/project/.worktrees/chan-1-engineer', input_tokens: 10000, output_tokens: 2000, cache_read_input_tokens: 0, total_cost_usd: 0.03 }),
+        makeEvent({ event_type: 'message_completed', project_key: 'chan-1:pm', project_dir: '/home/user/project', input_tokens: 5000, output_tokens: 1000, cache_read_input_tokens: 0, total_cost_usd: 0.01 }),
+      ]);
+      const engine = createActivityEngine(filePath);
+      const dirMap = { '/home/user/project': 'my-project' };
+      const rows = engine.tokensByProject('7d', dirMap);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].project_name).toBe('my-project');
+      expect(rows[0].input_tokens).toBe(15000);
     });
   });
 
@@ -268,7 +298,7 @@ describe('ActivityEngine', () => {
       const timeline = engine.sessionTimeline('7d');
       expect(timeline).toHaveLength(1);
       expect(timeline[0].session_id).toBe('sess-abc12345xyz');
-      expect(timeline[0].label).toBe('mpg/sess-abc/engineer');
+      expect(timeline[0].label).toBe('unknown/sess-abc/engineer');
       expect(timeline[0].segments).toHaveLength(3);
       // idle: session_start → message_routed
       expect(timeline[0].segments[0]).toEqual({
@@ -326,7 +356,7 @@ describe('ActivityEngine', () => {
       ]);
       const engine = createActivityEngine(filePath);
       const timeline = engine.sessionTimeline('7d');
-      expect(timeline[0].label).toBe('mpg/sess-noa/designer');
+      expect(timeline[0].label).toBe('unknown/sess-noa/designer');
     });
 
     it('falls back to "default" when no agent info available', () => {
@@ -338,7 +368,7 @@ describe('ActivityEngine', () => {
       ]);
       const engine = createActivityEngine(filePath);
       const timeline = engine.sessionTimeline('7d');
-      expect(timeline[0].label).toBe('mpg/sess-bar/default');
+      expect(timeline[0].label).toBe('unknown/sess-bar/default');
     });
 
     it('resolves project name from projectNameMap', () => {
@@ -351,6 +381,42 @@ describe('ActivityEngine', () => {
       const engine = createActivityEngine(filePath);
       const timeline = engine.sessionTimeline('7d', { '123456789': 'my-cool-project' });
       expect(timeline[0].label).toBe('my-cool-project/sess-pro/engineer');
+    });
+
+    it('resolves project name from dirToNameMap via project_dir', () => {
+      const t0 = new Date('2026-03-29T10:00:00Z');
+      const t1 = new Date('2026-03-29T10:01:00Z');
+      writeEvents(filePath, [
+        makeEvent({ event_type: 'session_start', session_id: 'sess-dir00000', timestamp: t0.toISOString(), project_key: '999', project_dir: '/home/user/my-project', agent_name: 'engineer' }),
+        makeEvent({ event_type: 'session_end', session_id: 'sess-dir00000', timestamp: t1.toISOString(), project_key: '999', project_dir: '/home/user/my-project' }),
+      ]);
+      const engine = createActivityEngine(filePath);
+      const timeline = engine.sessionTimeline('7d', {}, { '/home/user/my-project': 'cool-project' });
+      expect(timeline[0].label).toBe('cool-project/sess-dir/engineer');
+    });
+
+    it('resolves project name from dirToNameMap for worktree subdirectories', () => {
+      const t0 = new Date('2026-03-29T10:00:00Z');
+      const t1 = new Date('2026-03-29T10:01:00Z');
+      writeEvents(filePath, [
+        makeEvent({ event_type: 'session_start', session_id: 'sess-wt000000', timestamp: t0.toISOString(), project_key: '999:engineer', project_dir: '/home/user/project/.worktrees/999-engineer', agent_name: 'engineer' }),
+        makeEvent({ event_type: 'session_end', session_id: 'sess-wt000000', timestamp: t1.toISOString(), project_key: '999:engineer', project_dir: '/home/user/project/.worktrees/999-engineer' }),
+      ]);
+      const engine = createActivityEngine(filePath);
+      const timeline = engine.sessionTimeline('7d', {}, { '/home/user/project': 'my-project' });
+      expect(timeline[0].label).toBe('my-project/sess-wt0/engineer');
+    });
+
+    it('prefers dirToNameMap over channelId lookup', () => {
+      const t0 = new Date('2026-03-29T10:00:00Z');
+      const t1 = new Date('2026-03-29T10:01:00Z');
+      writeEvents(filePath, [
+        makeEvent({ event_type: 'session_start', session_id: 'sess-pref0000', timestamp: t0.toISOString(), project_key: '123456789', project_dir: '/home/user/project', agent_name: 'pm' }),
+        makeEvent({ event_type: 'session_end', session_id: 'sess-pref0000', timestamp: t1.toISOString(), project_key: '123456789', project_dir: '/home/user/project' }),
+      ]);
+      const engine = createActivityEngine(filePath);
+      const timeline = engine.sessionTimeline('7d', { '123456789': 'channel-name' }, { '/home/user/project': 'dir-name' });
+      expect(timeline[0].label).toBe('dir-name/sess-pre/pm');
     });
 
     it('resolves project name when project_key contains agent suffix', () => {
@@ -395,8 +461,8 @@ describe('ActivityEngine', () => {
       const timeline = engine.sessionTimeline('7d');
       expect(timeline).toHaveLength(2);
       const labels = timeline.map(t => t.label);
-      expect(labels).toContain('mpg/sess-aaa/pm');
-      expect(labels).toContain('mpg/sess-bbb/engineer');
+      expect(labels).toContain('unknown/sess-aaa/pm');
+      expect(labels).toContain('unknown/sess-bbb/engineer');
     });
 
     it('filters by time range', () => {

--- a/tests/dashboard-server.test.ts
+++ b/tests/dashboard-server.test.ts
@@ -83,8 +83,8 @@ describe('createDashboardServer', () => {
   it('returns 200 with health JSON on GET /health', async () => {
     const port = getPort();
     const sessions: SessionInfo[] = [
-      { sessionId: 'sess-1', projectKey: 'ch-1', lastActivity: Date.now(), queueLength: 0 },
-      { sessionId: 'sess-2', projectKey: 'ch-2', lastActivity: Date.now(), queueLength: 2 },
+      { sessionId: 'sess-1', projectKey: 'ch-1', cwd: '/home/user/project', lastActivity: Date.now(), queueLength: 0 },
+      { sessionId: 'sess-2', projectKey: 'ch-2', cwd: '/home/user/other', lastActivity: Date.now(), queueLength: 2 },
     ];
     server = await createDashboardServer(port, makeSessionManager(sessions), makeBot('connected'));
 
@@ -162,7 +162,7 @@ describe('createDashboardServer', () => {
     it('returns session list', async () => {
       const port = getPort();
       const sessions: SessionInfo[] = [
-        { sessionId: 'sess-1', projectKey: 'ch-1', lastActivity: 1700000000000, queueLength: 3 },
+        { sessionId: 'sess-1', projectKey: 'ch-1', cwd: '/home/user/project', lastActivity: 1700000000000, queueLength: 3 },
       ];
       server = await createDashboardServer(port, makeSessionManager(sessions), makeBot());
 
@@ -222,7 +222,7 @@ describe('createDashboardServer', () => {
     it('returns combined status overview', async () => {
       const port = getPort();
       const sessions: SessionInfo[] = [
-        { sessionId: 'sess-1', projectKey: 'ch-1', lastActivity: Date.now(), queueLength: 1 },
+        { sessionId: 'sess-1', projectKey: 'ch-1', cwd: '/home/user/project', lastActivity: Date.now(), queueLength: 1 },
       ];
       server = await createDashboardServer(port, makeSessionManager(sessions), makeBot('connected'), makeConfig());
 
@@ -258,7 +258,7 @@ describe('createDashboardServer', () => {
           total_sessions: 10, total_messages: 42, avg_session_duration_ms: 120000,
         }),
         tokensByProject: vi.fn().mockReturnValue([
-          { project_key: 'proj-a', project_dir: '/tmp/a', input_tokens: 300000, output_tokens: 30000, cache_read_input_tokens: 100000, cost_usd: 0.8, message_count: 25 },
+          { project_name: 'proj-a', input_tokens: 300000, output_tokens: 30000, cache_read_input_tokens: 100000, cost_usd: 0.8, message_count: 25 },
         ]),
         tokensBySession: vi.fn().mockReturnValue([
           { session_id: 'sess-1', project_key: 'proj-a', input_tokens: 150000, output_tokens: 15000, cost_usd: 0.4, message_count: 12, duration_ms: 60000 },
@@ -317,7 +317,7 @@ describe('createDashboardServer', () => {
       expect(body.project_name_map).toEqual({});
     });
 
-    it('GET /api/activity/summary includes project_name_map from config', async () => {
+    it('GET /api/activity/summary includes project_name_map and dir_to_name_map from config', async () => {
       const port = getPort();
       const engine = makeMockEngine();
       server = await createDashboardServer(port, makeSessionManager(), makeBot(), makeConfig(), {
@@ -326,6 +326,7 @@ describe('createDashboardServer', () => {
       const res = await httpGet(port, '/api/activity/summary?range=7d');
       const body = JSON.parse(res.body);
       expect(body.project_name_map).toEqual({ 'ch-1': 'My Project', 'ch-2': 'Other Project' });
+      expect(body.dir_to_name_map).toEqual({ '/home/user/project': 'My Project', '/home/user/other': 'Other Project' });
     });
   });
 
@@ -368,7 +369,7 @@ describe('createDashboardServer', () => {
       expect(body).toHaveLength(1);
       expect(body[0].label).toBe('mpg/sess-123/engineer');
       expect(body[0].segments).toHaveLength(2);
-      expect(engine.sessionTimeline).toHaveBeenCalledWith('24h', { 'ch-1': 'My Project', 'ch-2': 'Other Project' });
+      expect(engine.sessionTimeline).toHaveBeenCalledWith('24h', { 'ch-1': 'My Project', 'ch-2': 'Other Project' }, { '/home/user/project': 'My Project', '/home/user/other': 'Other Project' });
     });
 
     it('returns empty array when no engine provided', async () => {
@@ -387,7 +388,7 @@ describe('createDashboardServer', () => {
       });
       const res = await httpGet(port, '/api/activity/timeline?range=3h');
       expect(res.status).toBe(200);
-      expect(engine.sessionTimeline).toHaveBeenCalledWith('3h', { 'ch-1': 'My Project', 'ch-2': 'Other Project' });
+      expect(engine.sessionTimeline).toHaveBeenCalledWith('3h', { 'ch-1': 'My Project', 'ch-2': 'Other Project' }, { '/home/user/project': 'My Project', '/home/user/other': 'Other Project' });
     });
 
     it('accepts 12h range and passes it to engine', async () => {
@@ -398,7 +399,7 @@ describe('createDashboardServer', () => {
       });
       const res = await httpGet(port, '/api/activity/timeline?range=12h');
       expect(res.status).toBe(200);
-      expect(engine.sessionTimeline).toHaveBeenCalledWith('12h', { 'ch-1': 'My Project', 'ch-2': 'Other Project' });
+      expect(engine.sessionTimeline).toHaveBeenCalledWith('12h', { 'ch-1': 'My Project', 'ch-2': 'Other Project' }, { '/home/user/project': 'My Project', '/home/user/other': 'Other Project' });
     });
 
     it('returns 400 for invalid range', async () => {


### PR DESCRIPTION
## Summary
- **tokensByProject()** now accepts a `dirToNameMap` and aggregates by resolved project name instead of raw thread ID, so all agent sessions for the same project collapse into one row
- **sessionTimeline()** resolves project names via directory-based lookup (primary), channel ID (secondary), with `'unknown'` as final fallback — removes hardcoded `'mpg'`
- **Overview sessions table** resolves names from session `cwd`/`projectDir` against config directories, including worktree subdirectory matching
- **SessionInfo** now exposes `cwd` and `projectDir` fields so the dashboard can perform directory-based resolution

Closes #118

## Test plan
- [x] All 437 existing tests pass with updated assertions
- [x] New tests for `dirToNameMap` exact match, worktree subdirectory match, and priority over channel ID
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Manual verification: confirm dashboard shows correct project names in Timeline, Token Usage, and Sessions tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)