### PR TITLE
feat(#18): extract ChannelAdapter interface (Phase 0)

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -11,6 +11,8 @@ export interface ChannelAdapter {
   stop(): void;
   /** Return the current connection status as a human-readable string. */
   getStatus(): string;
+  /** Return the guild/server ID of the connected server, or null if not available or not applicable. */
+  getGuildId?(): string | null;
   /** Deliver a recovered orphaned session result back to the originating thread/channel. */
   deliverOrphanResult(projectKey: string, result: ClaudeResult): Promise<void>;
 }

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1,0 +1,16 @@
+import type { ClaudeResult } from './claude-cli.js';
+
+/**
+ * Platform-agnostic chat adapter interface.
+ * Each chat platform (Discord, Slack, etc.) implements this contract.
+ */
+export interface ChannelAdapter {
+  /** Connect to the chat platform and start listening for messages. */
+  start(): Promise<void>;
+  /** Disconnect and clean up resources. */
+  stop(): void;
+  /** Return the current connection status as a human-readable string. */
+  getStatus(): string;
+  /** Deliver a recovered orphaned session result back to the originating thread/channel. */
+  deliverOrphanResult(projectKey: string, result: ClaudeResult): Promise<void>;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -211,7 +211,7 @@ function start() {
   }
 
   const turnCounter = createTurnCounter();
-  const bot = createDiscordBot(router, sessionManager, config, turnCounter);
+  const bot = createDiscordBot(token, router, sessionManager, config, turnCounter);
 
   let dashboardServer: DashboardServer | undefined;
 
@@ -229,7 +229,7 @@ function start() {
   process.on('SIGINT', shutdown);
   process.on('SIGTERM', shutdown);
 
-  bot.start(token)
+  bot.start()
     .then(async () => {
       if (config.defaults.httpPort !== false) {
         try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import { ClaudeCliRuntime } from './runtimes/claude-cli-runtime.js';
 import { TmuxRuntime } from './runtimes/tmux-runtime.js';
 import type { AgentRuntime } from './agent-runtime.js';
 import { listSessions, killSession } from './tmux.js';
-import { createDiscordBot } from './discord.js';
+import { createAdapter } from './create-adapter.js';
 import { createPulseEmitter } from './pulse-events.js';
 import { createActivityEngine } from './activity-engine.js';
 import { createDashboardServer, type DashboardServer } from './dashboard-server.js';
@@ -211,7 +211,7 @@ function start() {
   }
 
   const turnCounter = createTurnCounter();
-  const bot = createDiscordBot(token, router, sessionManager, config, turnCounter);
+  const bot = createAdapter({ token, router, sessionManager, config, turnCounter });
 
   let dashboardServer: DashboardServer | undefined;
 

--- a/src/create-adapter.ts
+++ b/src/create-adapter.ts
@@ -12,10 +12,11 @@ export interface AdapterDeps {
   sessionManager: SessionManager;
   config: GatewayConfig;
   turnCounter?: TurnCounter;
+  platform?: string;
 }
 
 export function createAdapter(deps: AdapterDeps): ChannelAdapter {
-  const platform = process.env.CHAT_PLATFORM ?? 'discord';
+  const platform = deps.platform ?? process.env.CHAT_PLATFORM ?? 'discord';
 
   switch (platform) {
     case 'discord':

--- a/src/create-adapter.ts
+++ b/src/create-adapter.ts
@@ -1,0 +1,26 @@
+// src/create-adapter.ts
+import type { ChannelAdapter } from './adapter.js';
+import type { Router } from './router.js';
+import type { SessionManager } from './session-manager.js';
+import type { GatewayConfig } from './config.js';
+import type { TurnCounter } from './turn-counter.js';
+import { createDiscordBot } from './discord.js';
+
+export interface AdapterDeps {
+  token: string;
+  router: Router;
+  sessionManager: SessionManager;
+  config: GatewayConfig;
+  turnCounter?: TurnCounter;
+}
+
+export function createAdapter(deps: AdapterDeps): ChannelAdapter {
+  const platform = process.env.CHAT_PLATFORM ?? 'discord';
+
+  switch (platform) {
+    case 'discord':
+      return createDiscordBot(deps.token, deps.router, deps.sessionManager, deps.config, deps.turnCounter);
+    default:
+      throw new Error(`Unsupported CHAT_PLATFORM: ${platform}. Supported: discord`);
+  }
+}

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -1,7 +1,7 @@
 import { createServer, type Server } from 'node:http';
 import { readFileSync } from 'node:fs';
 import type { SessionManager } from './session-manager.js';
-import type { DiscordBot } from './discord.js';
+import type { ChannelAdapter } from './adapter.js';
 import type { GatewayConfig } from './config.js';
 import type { ActivityEngine, TimeRange, Bucket } from './activity-engine.js';
 
@@ -823,7 +823,7 @@ setInterval(function() {
 export function createDashboardServer(
   port: number,
   sessionManager: SessionManager,
-  bot: DiscordBot,
+  bot: ChannelAdapter,
   config?: GatewayConfig,
   options?: DashboardServerOptions,
 ): Promise<DashboardServer> {
@@ -884,7 +884,7 @@ export function createDashboardServer(
     }
 
     if (pathname === '/api/status') {
-      const discordGuildId = bot.getGuildId() ?? undefined;
+      const discordGuildId = bot.getGuildId?.() ?? undefined;
       const sessions = sessionManager.listSessions().map((s) => {
         const threadId = s.projectKey.includes(':') ? s.projectKey.split(':')[0] : s.projectKey;
         const gid = s.guildId ?? discordGuildId;

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -212,6 +212,7 @@ async function fetchThreadHistory(channel: TextChannel | ThreadChannel, beforeMe
   }
 }
 
+/** @internal Use {@link createAdapter} instead — this is the Discord-specific implementation. */
 export function createDiscordBot(token: string, router: Router, sessionManager: SessionManager, config: GatewayConfig, turnCounter?: TurnCounter): DiscordBot {
   const client = new Client({
     intents: [

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -6,6 +6,7 @@ import { buildToolArgs } from './claude-cli.js';
 import { parseAgentMention, parseAgentCommand, extractAskTarget, parseHandoffCommand, parseAllHandoffs, parseThreadName, stripThreadName } from './agent-dispatch.js';
 import { sendAgentMessage, buildHandoffEmbed, buildFanOutEmbed } from './embed-format.js';
 import type { TurnCounter } from './turn-counter.js';
+import type { ChannelAdapter } from './adapter.js';
 import { hasAllowedRole } from './role-check.js';
 import { createRateLimiter } from './rate-limiter.js';
 import { downloadAttachments, buildAttachmentPrompt, type AttachmentConfig, DEFAULT_ATTACHMENT_CONFIG } from './attachments.js';
@@ -56,14 +57,9 @@ export function chunkMessage(text: string, limit: number): string[] {
   return chunks;
 }
 
-export interface DiscordBot {
-  start(token: string): Promise<void>;
-  stop(): void;
-  getStatus(): string;
+export interface DiscordBot extends ChannelAdapter {
   /** Return the guild ID of the connected server, or null if not yet available. */
   getGuildId(): string | null;
-  /** Deliver an orphaned session result to the appropriate Discord thread. */
-  deliverOrphanResult(projectKey: string, result: import('./claude-cli.js').ClaudeResult): Promise<void>;
 }
 
 function resolveProjectName(config: GatewayConfig, channelId: string): string {
@@ -216,7 +212,7 @@ async function fetchThreadHistory(channel: TextChannel | ThreadChannel, beforeMe
   }
 }
 
-export function createDiscordBot(router: Router, sessionManager: SessionManager, config: GatewayConfig, turnCounter?: TurnCounter): DiscordBot {
+export function createDiscordBot(token: string, router: Router, sessionManager: SessionManager, config: GatewayConfig, turnCounter?: TurnCounter): DiscordBot {
   const client = new Client({
     intents: [
       GatewayIntentBits.Guilds,
@@ -686,7 +682,7 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
   });
 
   return {
-    async start(token: string) {
+    async start() {
       await client.login(token);
       console.log(`Gateway connected as ${client.user?.tag}`);
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { createRouter } from './router.js';
 import { createSessionManager } from './session-manager.js';
 import { createFileSessionStore } from './session-store.js';
 import { ClaudeCliRuntime } from './runtimes/claude-cli-runtime.js';
-import { createDiscordBot } from './discord.js';
+import { createAdapter } from './create-adapter.js';
 
 loadEnv();
 
@@ -31,7 +31,7 @@ const router = createRouter(config);
 const sessionStore = createFileSessionStore(resolve(process.cwd(), '.sessions.json'));
 const runtime = new ClaudeCliRuntime();
 const sessionManager = createSessionManager(config.defaults, runtime, sessionStore);
-const bot = createDiscordBot(token, router, sessionManager, config);
+const bot = createAdapter({ token, router, sessionManager, config });
 
 // Graceful shutdown
 function shutdown() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ const router = createRouter(config);
 const sessionStore = createFileSessionStore(resolve(process.cwd(), '.sessions.json'));
 const runtime = new ClaudeCliRuntime();
 const sessionManager = createSessionManager(config.defaults, runtime, sessionStore);
-const bot = createDiscordBot(router, sessionManager, config);
+const bot = createDiscordBot(token, router, sessionManager, config);
 
 // Graceful shutdown
 function shutdown() {
@@ -44,7 +44,7 @@ function shutdown() {
 process.on('SIGINT', shutdown);
 process.on('SIGTERM', shutdown);
 
-bot.start(token).catch((err) => {
+bot.start().catch((err) => {
   console.error('Failed to start bot:', err);
   process.exit(1);
 });

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import type { ChannelAdapter } from '../src/adapter.js';
+
+describe('ChannelAdapter interface', () => {
+  it('can be implemented with the required methods', () => {
+    const adapter: ChannelAdapter = {
+      start: async () => {},
+      stop: () => {},
+      getStatus: () => 'connected',
+      deliverOrphanResult: async () => {},
+    };
+
+    expect(adapter.start).toBeTypeOf('function');
+    expect(adapter.stop).toBeTypeOf('function');
+    expect(adapter.getStatus).toBeTypeOf('function');
+    expect(adapter.deliverOrphanResult).toBeTypeOf('function');
+  });
+
+  it('getStatus returns a string', () => {
+    const adapter: ChannelAdapter = {
+      start: async () => {},
+      stop: () => {},
+      getStatus: () => 'disconnected',
+      deliverOrphanResult: async () => {},
+    };
+
+    expect(adapter.getStatus()).toBe('disconnected');
+  });
+});

--- a/tests/create-adapter.test.ts
+++ b/tests/create-adapter.test.ts
@@ -1,0 +1,57 @@
+// tests/create-adapter.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock discord.ts so we don't need a real Discord client
+vi.mock('../src/discord.js', () => ({
+  createDiscordBot: vi.fn(() => ({
+    start: vi.fn(async () => {}),
+    stop: vi.fn(),
+    getStatus: vi.fn(() => 'connected'),
+    deliverOrphanResult: vi.fn(async () => {}),
+  })),
+}));
+
+import { createAdapter, type AdapterDeps } from '../src/create-adapter.js';
+import { createDiscordBot } from '../src/discord.js';
+
+function makeDeps(overrides?: Partial<AdapterDeps>): AdapterDeps {
+  return {
+    token: 'test-token',
+    router: {} as any,
+    sessionManager: {} as any,
+    config: { defaults: {}, projects: {} } as any,
+    turnCounter: undefined,
+    ...overrides,
+  };
+}
+
+describe('createAdapter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.CHAT_PLATFORM;
+  });
+
+  it('returns a discord adapter by default (no CHAT_PLATFORM set)', () => {
+    const adapter = createAdapter(makeDeps());
+    expect(createDiscordBot).toHaveBeenCalledWith(
+      'test-token',
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      undefined,
+    );
+    expect(adapter.start).toBeTypeOf('function');
+  });
+
+  it('returns a discord adapter when CHAT_PLATFORM=discord', () => {
+    process.env.CHAT_PLATFORM = 'discord';
+    const adapter = createAdapter(makeDeps());
+    expect(createDiscordBot).toHaveBeenCalled();
+    expect(adapter.getStatus).toBeTypeOf('function');
+  });
+
+  it('throws for unsupported platform', () => {
+    process.env.CHAT_PLATFORM = 'telegram';
+    expect(() => createAdapter(makeDeps())).toThrow('Unsupported CHAT_PLATFORM: telegram');
+  });
+});

--- a/tests/create-adapter.test.ts
+++ b/tests/create-adapter.test.ts
@@ -50,8 +50,16 @@ describe('createAdapter', () => {
     expect(adapter.getStatus).toBeTypeOf('function');
   });
 
-  it('throws for unsupported platform', () => {
+  it('respects platform field in deps over env var', () => {
     process.env.CHAT_PLATFORM = 'telegram';
-    expect(() => createAdapter(makeDeps())).toThrow('Unsupported CHAT_PLATFORM: telegram');
+    const adapter = createAdapter(makeDeps({ platform: 'discord' }));
+    expect(createDiscordBot).toHaveBeenCalled();
+    expect(adapter.start).toBeTypeOf('function');
+  });
+
+  it('throws for unsupported platform', () => {
+    expect(() => createAdapter(makeDeps({ platform: 'telegram' }))).toThrow(
+      'Unsupported CHAT_PLATFORM: telegram',
+    );
   });
 });

--- a/tests/dashboard-server.test.ts
+++ b/tests/dashboard-server.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import { request } from 'node:http';
 import { createDashboardServer, type DashboardServer } from '../src/dashboard-server.js';
 import type { SessionManager, SessionInfo } from '../src/session-manager.js';
-import type { DiscordBot } from '../src/discord.js';
+import type { ChannelAdapter } from '../src/adapter.js';
 import type { GatewayConfig } from '../src/config.js';
 
 function makeSessionManager(sessions: SessionInfo[] = []): SessionManager {
@@ -16,12 +16,13 @@ function makeSessionManager(sessions: SessionInfo[] = []): SessionManager {
   };
 }
 
-function makeBot(status = 'connected', guildId: string | null = null): DiscordBot {
+function makeBot(status = 'connected', guildId: string | null = null): ChannelAdapter {
   return {
     start: () => Promise.resolve(),
     stop: () => {},
     getStatus: () => status,
     getGuildId: () => guildId,
+    deliverOrphanResult: async () => {},
   };
 }
 


### PR DESCRIPTION
## Summary

Phase 0 of the Slack adapter work (issue #18) — extracts a platform-agnostic `ChannelAdapter` interface from the existing Discord bot so future adapters can be plugged in without touching entry points.

- **New `ChannelAdapter` interface** (`src/adapter.ts`) with `start()`, `stop()`, `getStatus()`, `deliverOrphanResult()`
- **Adapter factory** (`src/create-adapter.ts`) selects implementation via `CHAT_PLATFORM` env var (defaults to `discord`)
- **`DiscordBot` extends `ChannelAdapter`** — token moved from `start(token)` to factory parameter, marked `@internal`
- **Entry points** (`cli.ts`, `index.ts`) now use `createAdapter()` instead of `createDiscordBot()` directly
- **`dashboard-server.ts`** depends on `ChannelAdapter`, not `DiscordBot`

No Slack-specific code yet — just the abstraction layer. All existing Discord functionality works identically.

**Design decision:** `embed-format.ts` and `role-check.ts` are only consumed internally within `discord.ts`, so no shared formatting/ACL interfaces were created. Each adapter owns its own formatting and ACL internally. The `ChannelAdapter` interface itself is the abstraction boundary.

Closes #18 (Phase 0 only — Phases 1-3 will follow)

## Test plan

- [x] 448 tests pass (28 test files)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Production build succeeds (`npm run build`)
- [x] New tests for `ChannelAdapter` interface conformance
- [x] New tests for `createAdapter` factory (default platform, explicit platform, platform dep field precedence, unsupported platform error)
- [ ] Manual smoke test: start gateway with `CHAT_PLATFORM=discord` (or unset) and verify Discord bot connects normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)