### PR TITLE
feat(#139): enrich Pulse events with routing, handoff, and error tracking

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -433,10 +433,17 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
     if (turnCounter) turnCounter.reset(replyChannel.id);
 
     // Check for !ask <agent> command, @agent mention, or fall back to last active agent (#48, #60)
-    const mention = agents
-      ? (parseAgentCommand(message.content, agents) ?? parseAgentMention(message.content, agents))
-      : null;
-    const activeAgent = mention ?? (message.channel.isThread() ? lastActiveAgent.get(replyChannel.id) ?? null : null);
+    const explicitCommand = agents ? parseAgentCommand(message.content, agents) : null;
+    const mentionMatch = !explicitCommand && agents ? parseAgentMention(message.content, agents) : null;
+    const mention = explicitCommand ?? mentionMatch;
+    const lastActive = !mention && message.channel.isThread() ? lastActiveAgent.get(replyChannel.id) ?? null : null;
+    const activeAgent = mention ?? lastActive;
+
+    // Determine routing method for Pulse observability (#132)
+    const routingMethod = explicitCommand ? 'explicit_command' as const
+      : mentionMatch ? 'mention' as const
+      : lastActive ? 'last_active' as const
+      : 'default' as const;
 
     // Use thread ID for session keys so each thread gets its own agent sessions.
     // For main-channel messages, replyChannel is the newly created thread.
@@ -505,6 +512,7 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
           timeoutMs: activeAgent ? resolveAgentTimeout(activeAgent.agent, config.defaults) : config.defaults.agentTimeoutMs,
           extraArgs: primarySpawn.extraArgs,
           guildId: message.guildId ?? undefined,
+          routingMethod,
         },
       );
 
@@ -552,6 +560,7 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
                 fromAgent: currentAgentName,
                 toAgent: h.agentName,
                 threadId,
+                handoffDepth: turn,
               });
             }
 
@@ -576,7 +585,7 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
                 agentName: handoff.agentName,
                 result: await sessionManager.send(
                   key, spawn.cwd, responseText,
-                  { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: sysPrompt, timeoutMs: fanOutTimeout, extraArgs: spawn.extraArgs },
+                  { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: sysPrompt, timeoutMs: fanOutTimeout, extraArgs: spawn.extraArgs, routingMethod: 'handoff' },
                 ),
               };
             });
@@ -612,7 +621,7 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
               const synthSpawn = resolveLifeContextRun(currentAgentName ?? undefined, resolved.directory, toolArgs);
               synthesisResult = await sessionManager.send(
                 originKey, synthSpawn.cwd, synthesisPrompt,
-                { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: originSysPrompt, timeoutMs: originAgent ? resolveAgentTimeout(originAgent, config.defaults) : config.defaults.agentTimeoutMs, extraArgs: synthSpawn.extraArgs },
+                { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: originSysPrompt, timeoutMs: originAgent ? resolveAgentTimeout(originAgent, config.defaults) : config.defaults.agentTimeoutMs, extraArgs: synthSpawn.extraArgs, routingMethod: 'handoff' },
               );
             } catch (synthErr) {
               const msg = synthErr instanceof Error ? synthErr.message : String(synthErr);
@@ -648,6 +657,7 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
             fromAgent: currentAgentName,
             toAgent: handoff.agentName,
             threadId,
+            handoffDepth: turn,
           });
 
           if (turnCounter.isOverLimit(replyChannel.id, maxTurns)) {
@@ -679,7 +689,7 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
               handoffKey,
               handoffSpawn.cwd,
               responseText,
-              { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: handoffPrompt, timeoutMs: resolveAgentTimeout(handoff.agent, config.defaults), extraArgs: handoffSpawn.extraArgs },
+              { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: handoffPrompt, timeoutMs: resolveAgentTimeout(handoff.agent, config.defaults), extraArgs: handoffSpawn.extraArgs, routingMethod: 'handoff' },
             );
           } catch (handoffErr) {
             const msg = handoffErr instanceof Error ? handoffErr.message : String(handoffErr);

--- a/src/pulse-events.ts
+++ b/src/pulse-events.ts
@@ -3,14 +3,16 @@ import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 import type { ClaudeUsage } from './claude-cli.js';
 
+export type RoutingMethod = 'explicit_command' | 'mention' | 'last_active' | 'handoff' | 'default';
+
 export interface PulseEmitter {
   sessionStart(sessionId: string, projectKey: string, projectDir: string, opts?: { agentName?: string; triggerSource?: string }): void;
   sessionEnd(sessionId: string, projectKey: string, projectDir: string, durationMs: number, messageCount: number): void;
   sessionIdle(sessionId: string, projectKey: string, projectDir: string, durationMs: number, messageCount: number): void;
   sessionResume(sessionId: string, projectKey: string, projectDir: string, idleDurationMs: number): void;
-  messageRouted(sessionId: string, projectKey: string, projectDir: string, opts?: { agentTarget?: string; queueDepth?: number }): void;
-  messageCompleted(sessionId: string, projectKey: string, projectDir: string, usage: ClaudeUsage, opts?: { agentTarget?: string }): void;
-  agentHandoff(sessionId: string, projectKey: string, projectDir: string, opts: { fromAgent?: string; toAgent: string; threadId: string }): void;
+  messageRouted(sessionId: string, projectKey: string, projectDir: string, opts?: { agentTarget?: string; queueDepth?: number; routingMethod?: RoutingMethod }): void;
+  messageCompleted(sessionId: string, projectKey: string, projectDir: string, usage: ClaudeUsage, opts?: { agentTarget?: string; isError?: boolean; errorType?: string }): void;
+  agentHandoff(sessionId: string, projectKey: string, projectDir: string, opts: { fromAgent?: string; toAgent: string; threadId: string; handoffDepth?: number }): void;
 }
 
 const DEFAULT_PATH = join(homedir(), '.pulse', 'events', 'mpg-sessions.jsonl');
@@ -79,6 +81,7 @@ export function createPulseEmitter(filePath?: string): PulseEmitter {
         ...baseEvent('message_routed', sessionId, projectKey, projectDir),
         agent_target: opts?.agentTarget,
         queue_depth: opts?.queueDepth ?? 0,
+        routing_method: opts?.routingMethod ?? 'default',
       });
     },
 
@@ -86,6 +89,8 @@ export function createPulseEmitter(filePath?: string): PulseEmitter {
       emit({
         ...baseEvent('message_completed', sessionId, projectKey, projectDir),
         agent_target: opts?.agentTarget,
+        is_error: opts?.isError ?? false,
+        error_type: opts?.errorType,
         input_tokens: usage.input_tokens,
         output_tokens: usage.output_tokens,
         cache_creation_input_tokens: usage.cache_creation_input_tokens,
@@ -104,6 +109,7 @@ export function createPulseEmitter(filePath?: string): PulseEmitter {
         from_agent: opts.fromAgent,
         to_agent: opts.toAgent,
         thread_id: opts.threadId,
+        handoff_depth: opts.handoffDepth,
       });
     },
   };

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import { composeClaudeArgs, type ClaudeResult } from './claude-cli.js';
 import type { AgentRuntime } from './agent-runtime.js';
 import type { SessionStore, PersistedSession } from './session-store.js';
-import type { PulseEmitter } from './pulse-events.js';
+import type { PulseEmitter, RoutingMethod } from './pulse-events.js';
 import { createWorktree as gitCreateWorktree, removeWorktree as gitRemoveWorktree } from './worktree.js';
 import { cleanupAttachments } from './attachments.js';
 
@@ -29,7 +29,7 @@ export interface OrphanRecoveryCallbacks {
 }
 
 export interface SessionManager {
-  send(projectKey: string, cwd: string, prompt: string, opts?: { worktree?: boolean; systemPrompt?: string; timeoutMs?: number; extraArgs?: string[]; guildId?: string }): Promise<ClaudeResult>;
+  send(projectKey: string, cwd: string, prompt: string, opts?: { worktree?: boolean; systemPrompt?: string; timeoutMs?: number; extraArgs?: string[]; guildId?: string; routingMethod?: RoutingMethod }): Promise<ClaudeResult>;
   getSession(projectKey: string): SessionInfo | undefined;
   listSessions(): SessionInfo[];
   clearSession(projectKey: string): boolean;
@@ -38,7 +38,7 @@ export interface SessionManager {
   /** Discover orphaned tmux sessions and reattach to them. Call after Discord bot is ready. */
   recoverOrphanedSessions(callbacks: OrphanRecoveryCallbacks): Promise<void>;
   /** Emit an agent_handoff pulse event. No-op if pulse is disabled. */
-  emitHandoff(projectKey: string, cwd: string, opts: { fromAgent?: string; toAgent: string; threadId: string }): void;
+  emitHandoff(projectKey: string, cwd: string, opts: { fromAgent?: string; toAgent: string; threadId: string; handoffDepth?: number }): void;
 }
 
 interface InternalSession {
@@ -59,6 +59,7 @@ interface InternalSession {
     systemPrompt?: string;
     timeoutMs?: number;
     extraArgs?: string[];
+    routingMethod?: RoutingMethod;
     resolve: (result: ClaudeResult) => void;
     reject: (error: Error) => void;
   }>;
@@ -181,7 +182,7 @@ export function createSessionManager(defaults: {
           session.sessionId ?? session.projectKey,
           session.projectKey,
           session.cwd,
-          { agentTarget, queueDepth: session.queue.length },
+          { agentTarget, queueDepth: session.queue.length, routingMethod: item.routingMethod },
         );
       }
       try {
@@ -209,7 +210,7 @@ export function createSessionManager(defaults: {
             session.projectKey,
             session.cwd,
             result.usage,
-            { agentTarget },
+            { agentTarget, isError: result.isError, errorType: result.isError ? 'process_error' : undefined },
           );
         }
         resetIdleTimer(session);
@@ -234,7 +235,7 @@ export function createSessionManager(defaults: {
                 session.projectKey,
                 session.cwd,
                 result.usage,
-                { agentTarget },
+                { agentTarget, isError: result.isError, errorType: result.isError ? 'process_error' : undefined },
               );
             }
             resetIdleTimer(session);
@@ -373,10 +374,10 @@ export function createSessionManager(defaults: {
   }
 
   return {
-    send(projectKey: string, cwd: string, prompt: string, opts?: { worktree?: boolean; systemPrompt?: string; timeoutMs?: number; extraArgs?: string[]; guildId?: string }): Promise<ClaudeResult> {
+    send(projectKey: string, cwd: string, prompt: string, opts?: { worktree?: boolean; systemPrompt?: string; timeoutMs?: number; extraArgs?: string[]; guildId?: string; routingMethod?: RoutingMethod }): Promise<ClaudeResult> {
       const session = getOrCreateSession(projectKey, cwd, opts?.worktree, opts?.guildId);
       return new Promise<ClaudeResult>((resolve, reject) => {
-        session.queue.push({ prompt, systemPrompt: opts?.systemPrompt, timeoutMs: opts?.timeoutMs, extraArgs: opts?.extraArgs, resolve, reject });
+        session.queue.push({ prompt, systemPrompt: opts?.systemPrompt, timeoutMs: opts?.timeoutMs, extraArgs: opts?.extraArgs, routingMethod: opts?.routingMethod, resolve, reject });
         processQueue(session);
       });
     },
@@ -545,7 +546,7 @@ export function createSessionManager(defaults: {
       await Promise.all(reattachPromises);
     },
 
-    emitHandoff(projectKey: string, cwd: string, opts: { fromAgent?: string; toAgent: string; threadId: string }): void {
+    emitHandoff(projectKey: string, cwd: string, opts: { fromAgent?: string; toAgent: string; threadId: string; handoffDepth?: number }): void {
       if (!pulseEmitter) return;
       const session = sessions.get(projectKey);
       const sessionId = session?.sessionId ?? projectKey;

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -292,10 +292,17 @@ export function createSlackBot(
     if (turnCounter) turnCounter.reset(replyThreadTs);
 
     // Check for agent dispatch
-    const mention = agents
-      ? (parseAgentCommand(msg.text, agents) ?? parseAgentMention(msg.text, agents))
-      : null;
-    const activeAgent = mention ?? (isThread ? lastActiveAgent.get(replyThreadTs) ?? null : null);
+    const explicitCommand = agents ? parseAgentCommand(msg.text, agents) : null;
+    const mentionMatch = !explicitCommand && agents ? parseAgentMention(msg.text, agents) : null;
+    const mention = explicitCommand ?? mentionMatch;
+    const lastActive = !mention && isThread ? lastActiveAgent.get(replyThreadTs) ?? null : null;
+    const activeAgent = mention ?? lastActive;
+
+    // Determine routing method for Pulse observability (#132)
+    const routingMethod = explicitCommand ? 'explicit_command' as const
+      : mentionMatch ? 'mention' as const
+      : lastActive ? 'last_active' as const
+      : 'default' as const;
 
     // Session key: use thread_ts (or message ts for new threads) + optional agent name
     const sessionKey = activeAgent
@@ -329,6 +336,7 @@ export function createSlackBot(
           systemPrompt,
           timeoutMs: activeAgent ? resolveAgentTimeout(activeAgent.agent, config.defaults) : config.defaults.agentTimeoutMs,
           extraArgs: primarySpawn.extraArgs,
+          routingMethod,
         },
       );
 
@@ -377,6 +385,7 @@ export function createSlackBot(
                 fromAgent: currentAgentName,
                 toAgent: h.agentName,
                 threadId: replyThreadTs,
+                handoffDepth: turn,
               });
             }
 
@@ -409,7 +418,7 @@ export function createSlackBot(
                 agentName: handoff.agentName,
                 result: await sessionManager.send(
                   key, spawn.cwd, responseText,
-                  { worktree: true, systemPrompt: sysPrompt, timeoutMs: fanOutTimeout, extraArgs: spawn.extraArgs },
+                  { worktree: true, systemPrompt: sysPrompt, timeoutMs: fanOutTimeout, extraArgs: spawn.extraArgs, routingMethod: 'handoff' },
                 ),
               };
             });
@@ -442,7 +451,7 @@ export function createSlackBot(
               const synthSpawn = resolveLifeContextRun(currentAgentName ?? undefined, resolved.directory, toolArgs);
               synthesisResult = await sessionManager.send(
                 originKey, synthSpawn.cwd, synthesisPrompt,
-                { worktree: true, systemPrompt: originSysPrompt, timeoutMs: originAgent ? resolveAgentTimeout(originAgent, config.defaults) : config.defaults.agentTimeoutMs, extraArgs: synthSpawn.extraArgs },
+                { worktree: true, systemPrompt: originSysPrompt, timeoutMs: originAgent ? resolveAgentTimeout(originAgent, config.defaults) : config.defaults.agentTimeoutMs, extraArgs: synthSpawn.extraArgs, routingMethod: 'handoff' },
               );
             } catch (synthErr) {
               const errMsg = synthErr instanceof Error ? synthErr.message : String(synthErr);
@@ -476,6 +485,7 @@ export function createSlackBot(
             fromAgent: currentAgentName,
             toAgent: handoff.agentName,
             threadId: replyThreadTs,
+            handoffDepth: turn,
           });
 
           if (turnCounter.isOverLimit(replyThreadTs, maxTurns)) {
@@ -508,7 +518,7 @@ export function createSlackBot(
               handoffKey,
               handoffSpawn.cwd,
               responseText,
-              { worktree: true, systemPrompt: handoffPrompt, timeoutMs: resolveAgentTimeout(handoff.agent, config.defaults), extraArgs: handoffSpawn.extraArgs },
+              { worktree: true, systemPrompt: handoffPrompt, timeoutMs: resolveAgentTimeout(handoff.agent, config.defaults), extraArgs: handoffSpawn.extraArgs, routingMethod: 'handoff' },
             );
           } catch (handoffErr) {
             const errMsg = handoffErr instanceof Error ? handoffErr.message : String(handoffErr);

--- a/tests/pulse-events.test.ts
+++ b/tests/pulse-events.test.ts
@@ -71,6 +71,15 @@ describe('PulseEmitter', () => {
     expect(event.event_type).toBe('message_routed');
     expect(event.agent_target).toBe('pm');
     expect(event.queue_depth).toBe(2);
+    expect(event.routing_method).toBe('default');
+  });
+
+  it('emits message_routed with routing_method', () => {
+    const emitter = createPulseEmitter(filePath);
+    emitter.messageRouted('sess-1', 'project-a', '/tmp/project', { agentTarget: 'engineer', queueDepth: 0, routingMethod: 'explicit_command' });
+
+    const event = JSON.parse(readFileSync(filePath, 'utf-8').trim());
+    expect(event.routing_method).toBe('explicit_command');
   });
 
   it('appends multiple events to same file', () => {
@@ -106,6 +115,7 @@ describe('PulseEmitter', () => {
       fromAgent: 'pm',
       toAgent: 'engineer',
       threadId: 'thread-1',
+      handoffDepth: 2,
     });
 
     const event = JSON.parse(readFileSync(filePath, 'utf-8').trim());
@@ -114,6 +124,7 @@ describe('PulseEmitter', () => {
     expect(event.to_agent).toBe('engineer');
     expect(event.thread_id).toBe('thread-1');
     expect(event.session_id).toBe('sess-1');
+    expect(event.handoff_depth).toBe(2);
   });
 
   it('emits agent_handoff event with undefined fromAgent for user-initiated handoff', () => {
@@ -159,5 +170,25 @@ describe('PulseEmitter', () => {
     expect(event.duration_api_ms).toBe(38000);
     expect(event.num_turns).toBe(12);
     expect(event.model).toBe('claude-sonnet-4-20250514');
+    expect(event.is_error).toBe(false);
+    expect(event.error_type).toBeUndefined();
+  });
+
+  it('emits message_completed with error fields', () => {
+    const emitter = createPulseEmitter(filePath);
+    emitter.messageCompleted('sess-1', 'project-a', '/tmp/project', {
+      input_tokens: 1000,
+      output_tokens: 200,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+      total_cost_usd: 0.01,
+      duration_ms: 5000,
+      duration_api_ms: 4000,
+      num_turns: 1,
+    }, { agentTarget: 'engineer', isError: true, errorType: 'process_error' });
+
+    const event = JSON.parse(readFileSync(filePath, 'utf-8').trim());
+    expect(event.is_error).toBe(true);
+    expect(event.error_type).toBe('process_error');
   });
 });


### PR DESCRIPTION
## Summary
- Add `routing_method` field to `message_routed` events — values: `explicit_command`, `mention`, `last_active`, `handoff`, `default` (#132)
- Extend the existing `agent_handoff` event (landed in #169) with a `handoff_depth` field (#142). Kept `from_agent` / `to_agent` names for on-disk schema compatibility with events already written by #169 — see rebase comment below.
- Add `is_error` / `error_type` fields to `message_completed` events, set from `ClaudeResult.isError` (#143)
- #144: `session_resume` was already being emitted at both restore sites — no changes needed

Closes #132, #142, #143, #144
Parent: #139

## Schema-stability note

The original PR body proposed `source_agent` / `target_agent` field names on `agent_handoff`. During rebase those were kept as `from_agent` / `to_agent` because the initial `agent_handoff` event shape landed on master via #169 before this PR merged, and those field names are already on disk in `.pulse/events/mpg-sessions.jsonl`. Renaming would force Pulse consumers to handle two schemas. `handoff_depth` is added additively.

## Known limitations (follow-up-worthy)

- `handoff_depth` uses the session turn counter, which is incremented twice in fan-out dispatches. For single-agent chains `handoff_depth == chain depth`; for fan-out it reflects "turns consumed" rather than chain depth. Acceptable for now; worth refining if Pulse consumers want strict chain depth.
- `error_type: process_error` on the retry-after-session-reset path doesn't distinguish the retry's error from the initial error that triggered the reset. Follow-up if we want finer error taxonomy in Pulse.

## Test plan
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] All pulse-events + session-manager tests pass (60/60) — 3 new tests added for `routing_method`, `handoff_depth`, `is_error`
- [x] Full suite: 625+ passing / 2 pre-existing environmental failures unchanged
- [ ] Manual: verify `routing_method` appears in `.pulse/events/mpg-sessions.jsonl` on message dispatch
- [ ] Manual: verify `handoff_depth` appears on successful HANDOFF
- [ ] Manual: verify `is_error: true` appears when Claude returns an error result

🤖 Generated with [Claude Code](https://claude.com/claude-code)