### PR TITLE
fix(ayumi): inject Drive context into life-context agent prompts (#161)

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -10,8 +10,7 @@ import { hasAllowedRole } from './role-check.js';
 import { createRateLimiter } from './rate-limiter.js';
 import { downloadAttachments, buildAttachmentPrompt, type AttachmentConfig, DEFAULT_ATTACHMENT_CONFIG } from './attachments.js';
 import type { AgentConfig } from './config.js';
-import { loadDriveContext } from './ayumi/context-loader.js';
-import { createBrokerClient, type BrokerClient } from './broker-client.js';
+import { loadLifeContext } from './life-context-loader.js';
 
 export function chunkMessage(text: string, limit: number): string[] {
   if (text.length <= limit) return [text];
@@ -215,45 +214,11 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
 
   const rateLimiter = createRateLimiter();
 
-  // Broker client for loading Drive context (created lazily if env vars are set)
-  let brokerClient: BrokerClient | null = null;
-  function getBrokerClient(): BrokerClient | null {
-    if (brokerClient) return brokerClient;
-    const { BROKER_URL, BROKER_API_SECRET, BROKER_TENANT_ID, BROKER_ACTOR_ID } = process.env;
-    if (BROKER_URL && BROKER_API_SECRET && BROKER_TENANT_ID && BROKER_ACTOR_ID) {
-      brokerClient = createBrokerClient({
-        brokerUrl: BROKER_URL, apiSecret: BROKER_API_SECRET,
-        tenantId: BROKER_TENANT_ID, actorId: BROKER_ACTOR_ID,
-      });
-    }
-    return brokerClient;
-  }
-
-  // Cache loaded Drive context per agent name (loaded once, reused across messages)
-  const contextCache = new Map<string, string>();
-
-  async function buildSystemPrompt(agent: AgentConfig): Promise<string> {
+  // Build system prompt with optional Drive context injection (#161)
+  async function buildSystemPrompt(agentName: string, agent: AgentConfig): Promise<string> {
     const base = `Your role: ${agent.role}\n\n${agent.prompt}`;
-    if (!agent.contextPaths || agent.contextPaths.length === 0) return base;
-
-    // Check cache by contextPaths key (stable for a given preset)
-    const cacheKey = agent.contextPaths.join('|');
-    const cached = contextCache.get(cacheKey);
-    if (cached) return `${base}\n\n${cached}`;
-
-    const client = getBrokerClient();
-    if (!client) return base;
-
-    try {
-      const ctx = await loadDriveContext(agent.contextPaths, client);
-      if (ctx.content) {
-        contextCache.set(cacheKey, ctx.content);
-        return `${base}\n\n${ctx.content}`;
-      }
-    } catch (err) {
-      console.error('[context-loader] Failed to load Drive context:', err);
-    }
-    return base;
+    const ctx = await loadLifeContext(agentName);
+    return ctx ? `${base}\n\n${ctx}` : base;
   }
 
   // Track last active agent per thread for routing plain replies (#48)
@@ -407,7 +372,7 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
       ? `${threadId}:${activeAgent.agentName}`
       : threadId;
     const systemPrompt = activeAgent
-      ? await buildSystemPrompt(activeAgent.agent)
+      ? await buildSystemPrompt(activeAgent.agentName, activeAgent.agent)
       : undefined;
 
     try {
@@ -517,7 +482,7 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
             const fanOutTimeout = Math.min(config.defaults.agentTimeoutMs, 5 * 60 * 1000);
             const promises = allHandoffs.map(async (handoff) => {
               const key = `${threadId}:${handoff.agentName}`;
-              const sysPrompt = await buildSystemPrompt(handoff.agent);
+              const sysPrompt = await buildSystemPrompt(handoff.agentName, handoff.agent);
               return {
                 agentName: handoff.agentName,
                 result: await sessionManager.send(
@@ -549,7 +514,7 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
             const synthesisPrompt = `The user asked: "${responseText}"\n\nHere are the responses from the topic agents:\n\n${agentResponses.join('\n\n')}\n\nPlease synthesize these into a single coherent answer.`;
             const originKey = `${threadId}:${currentAgentName ?? 'life-router'}`;
             const originAgent = currentAgentName ? agents[currentAgentName] : undefined;
-            const originSysPrompt = originAgent ? await buildSystemPrompt(originAgent) : undefined;
+            const originSysPrompt = originAgent ? await buildSystemPrompt(currentAgentName!, originAgent) : undefined;
 
             replyChannel.sendTyping().catch(() => {});
 
@@ -596,7 +561,7 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
           }
 
           const handoffKey = `${threadId}:${handoff.agentName}`;
-          const handoffPrompt = await buildSystemPrompt(handoff.agent);
+          const handoffPrompt = await buildSystemPrompt(handoff.agentName, handoff.agent);
 
           replyChannel.sendTyping().catch(() => {});
 

--- a/src/life-context-loader.ts
+++ b/src/life-context-loader.ts
@@ -1,0 +1,106 @@
+/**
+ * Loads life-context data from Google Drive for topic agents.
+ * Maps agent names (life-work, life-travel, etc.) to Drive topics
+ * and fetches summary.md, timeline.md, entities.md files.
+ */
+
+import { createBrokerClient, type BrokerClient } from './broker-client.js';
+import type { FolderMap, TopicName } from './life-context-setup.js';
+
+const AGENT_TOPIC_MAP: Record<string, TopicName> = {
+  'life-work': 'work',
+  'life-travel': 'travel',
+  'life-social': 'social',
+  'life-hobbies': 'hobbies',
+};
+
+const CONTEXT_FILES = ['summary.md', 'timeline.md', 'entities.md'] as const;
+
+// Module-level singleton broker client
+let brokerClient: BrokerClient | null = null;
+let envWarned = false;
+
+function getOrCreateClient(): BrokerClient | null {
+  if (brokerClient) return brokerClient;
+
+  const { BROKER_URL, BROKER_API_SECRET, BROKER_TENANT_ID, BROKER_ACTOR_ID } = process.env;
+  if (!BROKER_URL || !BROKER_API_SECRET || !BROKER_TENANT_ID || !BROKER_ACTOR_ID) {
+    if (!envWarned) {
+      console.warn('[life-context-loader] Missing broker env vars (BROKER_URL, BROKER_API_SECRET, BROKER_TENANT_ID, BROKER_ACTOR_ID) — Drive context will not be loaded');
+      envWarned = true;
+    }
+    return null;
+  }
+
+  brokerClient = createBrokerClient({
+    brokerUrl: BROKER_URL,
+    apiSecret: BROKER_API_SECRET,
+    tenantId: BROKER_TENANT_ID,
+    actorId: BROKER_ACTOR_ID,
+  });
+  return brokerClient;
+}
+
+async function loadFolderMap(client: BrokerClient): Promise<FolderMap | null> {
+  const searchResult = await client.driveSearch('folder-map.json');
+  const mapFile = searchResult.files.find((f) => f.name === 'folder-map.json');
+  if (!mapFile) return null;
+  const content = await client.driveRead(mapFile.file_id);
+  return JSON.parse(content.content) as FolderMap;
+}
+
+/**
+ * Load life-context files from Drive for the given agent.
+ *
+ * @param agentName Agent preset name (e.g., 'life-work', 'life-travel')
+ * @returns Formatted context string, or null if not a life-context agent or loading fails
+ */
+export async function loadLifeContext(agentName: string): Promise<string | null> {
+  const topic = AGENT_TOPIC_MAP[agentName];
+  if (!topic) return null;
+
+  const client = getOrCreateClient();
+  if (!client) return null;
+
+  try {
+    const folderMap = await loadFolderMap(client);
+    if (!folderMap) {
+      console.error('[life-context-loader] folder-map.json not found in Drive');
+      return null;
+    }
+
+    const folderId = folderMap.topics[topic];
+    if (!folderId) {
+      console.error(`[life-context-loader] No folder ID for topic "${topic}" in folder-map`);
+      return null;
+    }
+
+    const listing = await client.driveList(folderId);
+    if (listing.files.length === 0) {
+      console.warn(`[life-context-loader] No files in ${topic} folder`);
+      return null;
+    }
+
+    const sections: string[] = [];
+    for (const filename of CONTEXT_FILES) {
+      const file = listing.files.find((f) => f.name === filename);
+      if (!file) continue;
+
+      const result = await client.driveRead(file.file_id);
+      sections.push(`## ${filename}\n${result.content}`);
+    }
+
+    if (sections.length === 0) return null;
+
+    return `--- LIFE CONTEXT DATA ---\n\n${sections.join('\n\n')}\n\n--- END LIFE CONTEXT DATA ---`;
+  } catch (err) {
+    console.error(`[life-context-loader] Error loading context for ${agentName}:`, err);
+    return null;
+  }
+}
+
+/** Reset module-level state (for testing). */
+export function _resetForTest(): void {
+  brokerClient = null;
+  envWarned = false;
+}

--- a/tests/life-context-loader.test.ts
+++ b/tests/life-context-loader.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock broker-client module before importing the loader
+vi.mock('../src/broker-client.js', () => ({
+  createBrokerClient: vi.fn(),
+}));
+
+import { loadLifeContext, _resetForTest } from '../src/life-context-loader.js';
+import { createBrokerClient } from '../src/broker-client.js';
+
+const mockCreateBrokerClient = vi.mocked(createBrokerClient);
+
+const FOLDER_MAP = {
+  root: 'root-id',
+  topics: { work: 'work-id', travel: 'travel-id', finance: 'finance-id', health: 'health-id', social: 'social-id', hobbies: 'hobbies-id' },
+  meta: 'meta-id',
+};
+
+function setupMockClient(overrides: Record<string, unknown> = {}) {
+  const client = {
+    driveSearch: vi.fn().mockResolvedValue({
+      files: [{ file_id: 'map-file-id', name: 'folder-map.json' }],
+    }),
+    driveRead: vi.fn()
+      .mockResolvedValueOnce({ content: JSON.stringify(FOLDER_MAP) }) // folder-map.json
+      .mockResolvedValueOnce({ content: '# Work Summary\nDetails.' }) // summary.md
+      .mockResolvedValueOnce({ content: '- 2025-01 Started job' }) // timeline.md
+      .mockResolvedValueOnce({ content: '## People\n- Alice' }), // entities.md
+    driveList: vi.fn().mockResolvedValue({
+      files: [
+        { file_id: 'summary-id', name: 'summary.md' },
+        { file_id: 'timeline-id', name: 'timeline.md' },
+        { file_id: 'entities-id', name: 'entities.md' },
+      ],
+    }),
+    ...overrides,
+  };
+  mockCreateBrokerClient.mockReturnValue(client as any);
+  return client;
+}
+
+beforeEach(() => {
+  _resetForTest();
+  vi.restoreAllMocks();
+  // Re-apply the mock since restoreAllMocks clears it
+  vi.mocked(createBrokerClient).mockReset();
+});
+
+describe('loadLifeContext', () => {
+  describe('agent name mapping', () => {
+    it('maps life-work to work topic', async () => {
+      process.env.BROKER_URL = 'http://broker';
+      process.env.BROKER_API_SECRET = 'secret';
+      process.env.BROKER_TENANT_ID = 'tenant';
+      process.env.BROKER_ACTOR_ID = 'actor';
+      const client = setupMockClient();
+
+      const result = await loadLifeContext('life-work');
+
+      expect(result).not.toBeNull();
+      expect(client.driveList).toHaveBeenCalledWith('work-id');
+    });
+
+    it('maps life-travel to travel topic', async () => {
+      process.env.BROKER_URL = 'http://broker';
+      process.env.BROKER_API_SECRET = 'secret';
+      process.env.BROKER_TENANT_ID = 'tenant';
+      process.env.BROKER_ACTOR_ID = 'actor';
+      const client = setupMockClient();
+
+      await loadLifeContext('life-travel');
+      expect(client.driveList).toHaveBeenCalledWith('travel-id');
+    });
+
+    it('maps life-social to social topic', async () => {
+      process.env.BROKER_URL = 'http://broker';
+      process.env.BROKER_API_SECRET = 'secret';
+      process.env.BROKER_TENANT_ID = 'tenant';
+      process.env.BROKER_ACTOR_ID = 'actor';
+      const client = setupMockClient();
+
+      await loadLifeContext('life-social');
+      expect(client.driveList).toHaveBeenCalledWith('social-id');
+    });
+
+    it('maps life-hobbies to hobbies topic', async () => {
+      process.env.BROKER_URL = 'http://broker';
+      process.env.BROKER_API_SECRET = 'secret';
+      process.env.BROKER_TENANT_ID = 'tenant';
+      process.env.BROKER_ACTOR_ID = 'actor';
+      const client = setupMockClient();
+
+      await loadLifeContext('life-hobbies');
+      expect(client.driveList).toHaveBeenCalledWith('hobbies-id');
+    });
+  });
+
+  describe('non-life agents return null', () => {
+    it.each(['life-router', 'curator', 'pm', 'engineer', 'unknown'])('%s returns null', async (name) => {
+      const result = await loadLifeContext(name);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('happy path', () => {
+    beforeEach(() => {
+      process.env.BROKER_URL = 'http://broker';
+      process.env.BROKER_API_SECRET = 'secret';
+      process.env.BROKER_TENANT_ID = 'tenant';
+      process.env.BROKER_ACTOR_ID = 'actor';
+    });
+
+    afterEach(() => {
+      delete process.env.BROKER_URL;
+      delete process.env.BROKER_API_SECRET;
+      delete process.env.BROKER_TENANT_ID;
+      delete process.env.BROKER_ACTOR_ID;
+    });
+
+    it('returns formatted context string with all three files', async () => {
+      setupMockClient();
+
+      const result = await loadLifeContext('life-work');
+
+      expect(result).not.toBeNull();
+      expect(result).toContain('--- LIFE CONTEXT DATA ---');
+      expect(result).toContain('--- END LIFE CONTEXT DATA ---');
+      expect(result).toContain('## summary.md');
+      expect(result).toContain('# Work Summary');
+      expect(result).toContain('## timeline.md');
+      expect(result).toContain('- 2025-01 Started job');
+      expect(result).toContain('## entities.md');
+      expect(result).toContain('## People');
+    });
+
+    it('skips files not present in folder listing', async () => {
+      const client = setupMockClient();
+      client.driveList.mockResolvedValue({
+        files: [{ file_id: 'summary-id', name: 'summary.md' }],
+      });
+      // Only folder-map + summary reads
+      client.driveRead
+        .mockReset()
+        .mockResolvedValueOnce({ content: JSON.stringify(FOLDER_MAP) })
+        .mockResolvedValueOnce({ content: '# Summary only' });
+
+      const result = await loadLifeContext('life-work');
+
+      expect(result).toContain('## summary.md');
+      expect(result).not.toContain('## timeline.md');
+      expect(result).not.toContain('## entities.md');
+    });
+  });
+
+  describe('missing broker env vars', () => {
+    it('returns null with warning log', async () => {
+      delete process.env.BROKER_URL;
+      delete process.env.BROKER_API_SECRET;
+      delete process.env.BROKER_TENANT_ID;
+      delete process.env.BROKER_ACTOR_ID;
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await loadLifeContext('life-work');
+
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Missing broker env vars'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('warns only once across multiple calls', async () => {
+      delete process.env.BROKER_URL;
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await loadLifeContext('life-work');
+      await loadLifeContext('life-travel');
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('broker errors', () => {
+    beforeEach(() => {
+      process.env.BROKER_URL = 'http://broker';
+      process.env.BROKER_API_SECRET = 'secret';
+      process.env.BROKER_TENANT_ID = 'tenant';
+      process.env.BROKER_ACTOR_ID = 'actor';
+    });
+
+    afterEach(() => {
+      delete process.env.BROKER_URL;
+      delete process.env.BROKER_API_SECRET;
+      delete process.env.BROKER_TENANT_ID;
+      delete process.env.BROKER_ACTOR_ID;
+    });
+
+    it('returns null when driveSearch throws', async () => {
+      const client = setupMockClient();
+      client.driveSearch.mockRejectedValue(new Error('Network error'));
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = await loadLifeContext('life-work');
+
+      expect(result).toBeNull();
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error loading context'),
+        expect.any(Error),
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('returns null when folder-map.json is not found', async () => {
+      const client = setupMockClient();
+      client.driveSearch.mockResolvedValue({ files: [] });
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = await loadLifeContext('life-work');
+
+      expect(result).toBeNull();
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('folder-map.json not found'),
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('returns null when topic folder is empty', async () => {
+      const client = setupMockClient();
+      client.driveList.mockResolvedValue({ files: [] });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await loadLifeContext('life-work');
+
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('No files in work folder'),
+      );
+      warnSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/life-context-loader.ts` — fetches topic-specific Drive files (summary.md, timeline.md, entities.md) via broker client and formats them for system prompt injection
- Modifies `src/discord.ts` — calls `loadLifeContext(agentName)` at all dispatch points (direct, single handoff, fan-out) so life-context agents receive curated Drive data in their system prompt
- Graceful degradation: missing env vars, broker errors, missing files all return null with logging — agents still work with base prompt

Closes #161
Unblocks #160 (manual E2E validation)

## Test plan
- [ ] 537 tests passing (16 new for life-context-loader)
- [ ] Deploy bot and run manual E2E test cases from #160
- [ ] Verify bot logs show `[context-loader]` messages on dispatch
- [ ] Verify agent responses cite specific details from Drive context


🤖 Generated with [Claude Code](https://claude.com/claude-code)