### PR TITLE
feat: per-agent timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ You can define multiple agents per project that collaborate via `@mentions`. Eac
 
 ### Defining agents
 
-Add an `agents` map to any project in `config.json`. Each key is the agent name (used as `@name` in Discord), with `role` and `prompt` fields:
+Add an `agents` map to any project in `config.json`. Each key is the agent name (used as `@name` in Discord), with `role` and `prompt` fields. You can optionally set a per-agent `timeoutMs` to override `defaults.agentTimeoutMs`:
 
 ```json
 {
@@ -313,17 +313,21 @@ Add an `agents` map to any project in `config.json`. Each key is the agent name 
       "agents": {
         "pm": {
           "role": "Product Manager",
-          "prompt": "You are the PM for my-app. Analyze requirements, create issues, and review work. When you need code implemented, mention @engineer in your response. Never write code directly."
+          "prompt": "You are the PM for my-app. Analyze requirements, create issues, and review work. When you need code implemented, mention @engineer in your response. Never write code directly.",
+          "timeoutMs": 300000
         },
         "engineer": {
           "role": "Software Engineer",
-          "prompt": "You are a senior engineer for my-app. Implement features, write tests, fix bugs, and create PRs. When work is done or you need PM review, mention @pm in your response."
+          "prompt": "You are a senior engineer for my-app. Implement features, write tests, fix bugs, and create PRs. When work is done or you need PM review, mention @pm in your response.",
+          "timeoutMs": 1800000
         }
       }
     }
   }
 }
 ```
+
+The timeout resolution order is: agent-specific `timeoutMs` → `defaults.agentTimeoutMs` (3 min).
 
 ### How agent routing works
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ export interface AgentConfig {
   role: string;
   prompt: string;
   contextPaths?: string[];
+  timeoutMs?: number;
 }
 
 export interface AgentInputConfig {
@@ -106,6 +107,8 @@ export function loadConfig(raw: unknown): GatewayConfig {
         const ac = agentCfg as Record<string, unknown>;
         const name = agentName.toLowerCase();
 
+        const agentTimeoutMs = typeof ac.timeoutMs === 'number' && ac.timeoutMs > 0 ? ac.timeoutMs : undefined;
+
         if (typeof ac.preset === 'string') {
           // Preset-based: resolve preset, then merge overrides
           const preset = resolvePreset(ac.preset);
@@ -114,11 +117,11 @@ export function loadConfig(raw: unknown): GatewayConfig {
             const basePrompt = preset.prompt;
             const extra = typeof ac.prompt === 'string' ? ac.prompt : '';
             const prompt = extra ? `${basePrompt}\n\n${extra}` : basePrompt;
-            agents[name] = { role, prompt };
+            agents[name] = { role, prompt, ...(agentTimeoutMs !== undefined && { timeoutMs: agentTimeoutMs }) };
           }
         } else if (typeof ac.role === 'string' && typeof ac.prompt === 'string') {
           // Inline: original behavior
-          agents[name] = { role: ac.role, prompt: ac.prompt };
+          agents[name] = { role: ac.role, prompt: ac.prompt, ...(agentTimeoutMs !== undefined && { timeoutMs: agentTimeoutMs }) };
         }
       }
       if (Object.keys(agents).length === 0) agents = undefined;
@@ -178,4 +181,11 @@ export function loadConfig(raw: unknown): GatewayConfig {
     },
     projects: validated,
   };
+}
+
+/**
+ * Resolve timeout for a specific agent: agent-specific → global default.
+ */
+export function resolveAgentTimeout(agent: AgentConfig, defaults: GatewayDefaults): number {
+  return agent.timeoutMs ?? defaults.agentTimeoutMs;
 }

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -1,7 +1,7 @@
 import { Client, GatewayIntentBits, Events, Status, type Message, type TextChannel, type ThreadChannel } from 'discord.js';
 import type { Router } from './router.js';
 import type { SessionManager } from './session-manager.js';
-import type { GatewayConfig } from './config.js';
+import { type GatewayConfig, resolveAgentTimeout } from './config.js';
 import { buildToolArgs } from './claude-cli.js';
 import { parseAgentMention, parseAgentCommand, extractAskTarget, parseHandoffCommand, parseAllHandoffs } from './agent-dispatch.js';
 import { sendAgentMessage, buildHandoffEmbed, buildFanOutEmbed } from './embed-format.js';
@@ -479,10 +479,10 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
 
             // Dispatch all agents in parallel
             const fanOutStart = Date.now();
-            const fanOutTimeout = Math.min(config.defaults.agentTimeoutMs, 5 * 60 * 1000);
             const promises = allHandoffs.map(async (handoff) => {
               const key = `${threadId}:${handoff.agentName}`;
               const sysPrompt = await buildSystemPrompt(handoff.agentName, handoff.agent);
+              const fanOutTimeout = Math.min(resolveAgentTimeout(handoff.agent, config.defaults), 5 * 60 * 1000);
               return {
                 agentName: handoff.agentName,
                 result: await sessionManager.send(
@@ -522,7 +522,7 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
             try {
               synthesisResult = await sessionManager.send(
                 originKey, resolved.directory, synthesisPrompt,
-                { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: originSysPrompt, timeoutMs: config.defaults.agentTimeoutMs, extraArgs: toolArgs.length > 0 ? toolArgs : undefined },
+                { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: originSysPrompt, timeoutMs: originAgent ? resolveAgentTimeout(originAgent, config.defaults) : config.defaults.agentTimeoutMs, extraArgs: toolArgs.length > 0 ? toolArgs : undefined },
               );
             } catch (synthErr) {
               const msg = synthErr instanceof Error ? synthErr.message : String(synthErr);
@@ -580,7 +580,7 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
               handoffKey,
               resolved.directory,
               responseText,
-              { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: handoffPrompt, timeoutMs: config.defaults.agentTimeoutMs, extraArgs: toolArgs.length > 0 ? toolArgs : undefined },
+              { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: handoffPrompt, timeoutMs: resolveAgentTimeout(handoff.agent, config.defaults), extraArgs: toolArgs.length > 0 ? toolArgs : undefined },
             );
           } catch (handoffErr) {
             const msg = handoffErr instanceof Error ? handoffErr.message : String(handoffErr);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { loadConfig, DEFAULT_ALLOWED_TOOLS, type GatewayConfig } from '../src/config.js';
+import { loadConfig, DEFAULT_ALLOWED_TOOLS, resolveAgentTimeout, type GatewayConfig, type GatewayDefaults, type AgentConfig } from '../src/config.js';
 import { PERSONA_PRESETS } from '../src/persona-presets.js';
 
 describe('loadConfig', () => {
@@ -439,5 +439,95 @@ describe('loadConfig', () => {
       projects: { 'ch-1': { directory: '/tmp/a' } },
     });
     expect(config.defaults.persistence).toBe('direct');
+  });
+
+  // --- per-agent timeoutMs ---
+
+  it('parses per-agent timeoutMs from inline agent config', () => {
+    const config = loadConfig({
+      projects: {
+        'ch-1': {
+          directory: '/tmp/app',
+          agents: {
+            engineer: { role: 'Engineer', prompt: 'You write code.', timeoutMs: 1800000 },
+            pm: { role: 'PM', prompt: 'You manage.', timeoutMs: 300000 },
+          },
+        },
+      },
+    });
+    expect(config.projects['ch-1'].agents!.engineer.timeoutMs).toBe(1800000);
+    expect(config.projects['ch-1'].agents!.pm.timeoutMs).toBe(300000);
+  });
+
+  it('parses per-agent timeoutMs from preset-based agent config', () => {
+    const config = loadConfig({
+      projects: {
+        'ch-1': {
+          directory: '/tmp/app',
+          agents: {
+            engineer: { preset: 'engineer', timeoutMs: 900000 },
+          },
+        },
+      },
+    });
+    expect(config.projects['ch-1'].agents!.engineer.timeoutMs).toBe(900000);
+  });
+
+  it('omits timeoutMs when not specified in agent config', () => {
+    const config = loadConfig({
+      projects: {
+        'ch-1': {
+          directory: '/tmp/app',
+          agents: {
+            pm: { role: 'PM', prompt: 'You manage.' },
+          },
+        },
+      },
+    });
+    expect(config.projects['ch-1'].agents!.pm.timeoutMs).toBeUndefined();
+  });
+
+  it('ignores non-positive timeoutMs values', () => {
+    const config = loadConfig({
+      projects: {
+        'ch-1': {
+          directory: '/tmp/app',
+          agents: {
+            pm: { role: 'PM', prompt: 'You manage.', timeoutMs: 0 },
+            engineer: { role: 'Engineer', prompt: 'You code.', timeoutMs: -1 },
+          },
+        },
+      },
+    });
+    expect(config.projects['ch-1'].agents!.pm.timeoutMs).toBeUndefined();
+    expect(config.projects['ch-1'].agents!.engineer.timeoutMs).toBeUndefined();
+  });
+
+  it('ignores non-number timeoutMs values', () => {
+    const config = loadConfig({
+      projects: {
+        'ch-1': {
+          directory: '/tmp/app',
+          agents: {
+            pm: { role: 'PM', prompt: 'You manage.', timeoutMs: 'fast' },
+          },
+        },
+      },
+    });
+    expect(config.projects['ch-1'].agents!.pm.timeoutMs).toBeUndefined();
+  });
+});
+
+describe('resolveAgentTimeout', () => {
+  const defaults = { agentTimeoutMs: 180000 } as GatewayDefaults;
+
+  it('returns agent-specific timeout when set', () => {
+    const agent: AgentConfig = { role: 'Engineer', prompt: 'code', timeoutMs: 1800000 };
+    expect(resolveAgentTimeout(agent, defaults)).toBe(1800000);
+  });
+
+  it('falls back to global default when agent has no timeoutMs', () => {
+    const agent: AgentConfig = { role: 'PM', prompt: 'manage' };
+    expect(resolveAgentTimeout(agent, defaults)).toBe(180000);
   });
 });


### PR DESCRIPTION
## Summary
- Add optional `timeoutMs` field to per-agent config, resolved before the global `defaults.agentTimeoutMs` fallback
- Export `resolveAgentTimeout()` helper for clean timeout resolution: agent-specific → global default
- Handoff in `discord.ts` now uses per-agent timeout when available

Closes #164

## Changes
- **`src/config.ts`** — Added `timeoutMs?: number` to `AgentConfig`, parsed/validated at config load time (must be positive number), added `resolveAgentTimeout()` export
- **`src/discord.ts`** — Replaced hardcoded `config.defaults.agentTimeoutMs` with `resolveAgentTimeout(handoff.agent, config.defaults)`
- **`tests/config.test.ts`** — 7 new tests: inline timeoutMs, preset timeoutMs, omitted timeoutMs, non-positive values, non-number values, and resolveAgentTimeout resolution chain
- **`README.md`** — Documented per-agent timeoutMs in the multi-agent setup section with config example

## Config example
```json
{
  "agents": {
    "pm": { "role": "PM", "prompt": "...", "timeoutMs": 300000 },
    "engineer": { "role": "Engineer", "prompt": "...", "timeoutMs": 1800000 }
  }
}
```

## Test plan
- [x] All 487 existing tests pass
- [x] 7 new tests cover: inline/preset timeoutMs parsing, omission, invalid values, resolution chain
- [ ] Manual: set per-agent timeoutMs in config, verify engineer gets longer timeout than PM

🤖 Generated with [Claude Code](https://claude.com/claude-code)