### PR TITLE
feat: emit agent_handoff pulse events and populate agentName on session_start

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -467,6 +467,15 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
             const turn = turnCounter.getTurns(replyChannel.id);
             console.log(`[fan-out] thread=${replyChannel.id} turn=${turn}/${maxTurns} ${currentAgentName ?? 'user'} → [${allHandoffs.map(h => h.agentName).join(', ')}]`);
 
+            // Emit agent_handoff pulse events for each fan-out target
+            for (const h of allHandoffs) {
+              sessionManager.emitHandoff(`${threadId}:${h.agentName}`, resolved.directory, {
+                fromAgent: currentAgentName,
+                toAgent: h.agentName,
+                threadId,
+              });
+            }
+
             if (turnCounter.isOverLimit(replyChannel.id, maxTurns)) {
               console.log(`[fan-out] thread=${replyChannel.id} turn limit reached, stopping`);
               await replyChannel.send(`⚠️ Agent turn limit reached (${maxTurns}) — send a message to reset.`);
@@ -551,6 +560,13 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
           turnCounter.increment(replyChannel.id);
           const turn = turnCounter.getTurns(replyChannel.id);
           console.log(`[handoff] thread=${replyChannel.id} turn=${turn}/${maxTurns} ${currentAgentName ?? 'user'} → ${handoff.agentName}`);
+
+          // Emit agent_handoff pulse event
+          sessionManager.emitHandoff(`${threadId}:${handoff.agentName}`, resolved.directory, {
+            fromAgent: currentAgentName,
+            toAgent: handoff.agentName,
+            threadId,
+          });
 
           if (turnCounter.isOverLimit(replyChannel.id, maxTurns)) {
             console.log(`[handoff] thread=${replyChannel.id} turn limit reached, stopping`);

--- a/src/pulse-events.ts
+++ b/src/pulse-events.ts
@@ -10,6 +10,7 @@ export interface PulseEmitter {
   sessionResume(sessionId: string, projectKey: string, projectDir: string, idleDurationMs: number): void;
   messageRouted(sessionId: string, projectKey: string, projectDir: string, opts?: { agentTarget?: string; queueDepth?: number }): void;
   messageCompleted(sessionId: string, projectKey: string, projectDir: string, usage: ClaudeUsage, opts?: { agentTarget?: string }): void;
+  agentHandoff(sessionId: string, projectKey: string, projectDir: string, opts: { fromAgent?: string; toAgent: string; threadId: string }): void;
 }
 
 const DEFAULT_PATH = join(homedir(), '.pulse', 'events', 'mpg-sessions.jsonl');
@@ -94,6 +95,15 @@ export function createPulseEmitter(filePath?: string): PulseEmitter {
         duration_api_ms: usage.duration_api_ms,
         num_turns: usage.num_turns,
         model: usage.model,
+      });
+    },
+
+    agentHandoff(sessionId, projectKey, projectDir, opts) {
+      emit({
+        ...baseEvent('agent_handoff', sessionId, projectKey, projectDir),
+        from_agent: opts.fromAgent,
+        to_agent: opts.toAgent,
+        thread_id: opts.threadId,
       });
     },
   };

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -29,6 +29,8 @@ export interface SessionManager {
   shutdown(): void;
   /** Discover orphaned tmux sessions and reattach to them. Call after Discord bot is ready. */
   recoverOrphanedSessions(onResult: OrphanResultCallback): Promise<void>;
+  /** Emit an agent_handoff pulse event. No-op if pulse is disabled. */
+  emitHandoff(projectKey: string, cwd: string, opts: { fromAgent?: string; toAgent: string; threadId: string }): void;
 }
 
 interface InternalSession {
@@ -310,11 +312,12 @@ export function createSessionManager(defaults: {
             Date.now() - (restoredLastActivity ?? Date.now()),
           );
         } else {
+          const agentName = projectKey.includes(':') ? projectKey.split(':').pop() : undefined;
           pulseEmitter.sessionStart(
             session.sessionId ?? projectKey,
             projectKey,
             effectiveCwd,
-            { triggerSource: 'discord' },
+            { agentName, triggerSource: 'discord' },
           );
         }
       }
@@ -493,6 +496,13 @@ export function createSessionManager(defaults: {
       }
 
       await Promise.all(reattachPromises);
+    },
+
+    emitHandoff(projectKey: string, cwd: string, opts: { fromAgent?: string; toAgent: string; threadId: string }): void {
+      if (!pulseEmitter) return;
+      const session = sessions.get(projectKey);
+      const sessionId = session?.sessionId ?? projectKey;
+      pulseEmitter.agentHandoff(sessionId, projectKey, cwd, opts);
     },
 
     shutdown() {

--- a/tests/pulse-events.test.ts
+++ b/tests/pulse-events.test.ts
@@ -100,6 +100,35 @@ describe('PulseEmitter', () => {
     }).not.toThrow();
   });
 
+  it('emits agent_handoff event', () => {
+    const emitter = createPulseEmitter(filePath);
+    emitter.agentHandoff('sess-1', 'thread-1:engineer', '/tmp/project', {
+      fromAgent: 'pm',
+      toAgent: 'engineer',
+      threadId: 'thread-1',
+    });
+
+    const event = JSON.parse(readFileSync(filePath, 'utf-8').trim());
+    expect(event.event_type).toBe('agent_handoff');
+    expect(event.from_agent).toBe('pm');
+    expect(event.to_agent).toBe('engineer');
+    expect(event.thread_id).toBe('thread-1');
+    expect(event.session_id).toBe('sess-1');
+  });
+
+  it('emits agent_handoff event with undefined fromAgent for user-initiated handoff', () => {
+    const emitter = createPulseEmitter(filePath);
+    emitter.agentHandoff('sess-1', 'thread-1:engineer', '/tmp/project', {
+      toAgent: 'engineer',
+      threadId: 'thread-1',
+    });
+
+    const event = JSON.parse(readFileSync(filePath, 'utf-8').trim());
+    expect(event.event_type).toBe('agent_handoff');
+    expect(event.from_agent).toBeUndefined();
+    expect(event.to_agent).toBe('engineer');
+  });
+
   it('emits message_completed event with usage payload', () => {
     const emitter = createPulseEmitter(filePath);
     emitter.messageCompleted('sess-1', 'project-a', '/tmp/project', {

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -417,6 +417,7 @@ describe('SessionManager', () => {
       sessionResume: ReturnType<typeof vi.fn>;
       messageRouted: ReturnType<typeof vi.fn>;
       messageCompleted: ReturnType<typeof vi.fn>;
+      agentHandoff: ReturnType<typeof vi.fn>;
     };
     let pulseManager: SessionManager;
 
@@ -431,6 +432,7 @@ describe('SessionManager', () => {
         sessionResume: vi.fn(),
         messageRouted: vi.fn(),
         messageCompleted: vi.fn(),
+        agentHandoff: vi.fn(),
       };
       pulseManager = createSessionManager(defaults, pulseRuntime, undefined, pulseEmitter);
     });
@@ -444,6 +446,22 @@ describe('SessionManager', () => {
       expect(pulseEmitter.sessionStart).toHaveBeenCalledOnce();
       expect(pulseEmitter.sessionStart).toHaveBeenCalledWith(
         expect.any(String), 'project-a', '/tmp/a', expect.objectContaining({ triggerSource: 'discord' }),
+      );
+    });
+
+    it('emits session_start with agentName when project key contains agent', async () => {
+      await pulseManager.send('thread-1:engineer', '/tmp/a', 'Hello');
+      expect(pulseEmitter.sessionStart).toHaveBeenCalledWith(
+        expect.any(String), 'thread-1:engineer', '/tmp/a',
+        expect.objectContaining({ agentName: 'engineer', triggerSource: 'discord' }),
+      );
+    });
+
+    it('emits session_start without agentName for plain project keys', async () => {
+      await pulseManager.send('project-a', '/tmp/a', 'Hello');
+      expect(pulseEmitter.sessionStart).toHaveBeenCalledWith(
+        expect.any(String), 'project-a', '/tmp/a',
+        expect.objectContaining({ agentName: undefined, triggerSource: 'discord' }),
       );
     });
 
@@ -535,6 +553,20 @@ describe('SessionManager', () => {
     it('does not emit message_completed when usage is absent', async () => {
       await pulseManager.send('project-a', '/tmp/a', 'Hello');
       expect(pulseEmitter.messageCompleted).not.toHaveBeenCalled();
+    });
+
+    it('emitHandoff emits agent_handoff pulse event', async () => {
+      await pulseManager.send('thread-1:pm', '/tmp/a', 'Hello');
+      pulseManager.emitHandoff('thread-1:engineer', '/tmp/a', {
+        fromAgent: 'pm',
+        toAgent: 'engineer',
+        threadId: 'thread-1',
+      });
+      expect(pulseEmitter.agentHandoff).toHaveBeenCalledOnce();
+      expect(pulseEmitter.agentHandoff).toHaveBeenCalledWith(
+        expect.any(String), 'thread-1:engineer', '/tmp/a',
+        { fromAgent: 'pm', toAgent: 'engineer', threadId: 'thread-1' },
+      );
     });
   });
 
@@ -637,6 +669,7 @@ describe('SessionManager', () => {
         sessionResume: vi.fn(),
         messageRouted: vi.fn(),
         messageCompleted: vi.fn(),
+        agentHandoff: vi.fn(),
       };
       const m = createSessionManager(defaults, rt, store, pulseEmitter);
       await m.recoverOrphanedSessions(vi.fn());


### PR DESCRIPTION
## Summary
- **`sessionStart` now includes `agentName`** — extracted from project key (`threadId:agentName`), so Pulse can identify which agent a session belongs to
- **New `agent_handoff` event** — emitted on both single handoffs and fan-out dispatches, enabling Pulse to detect handoff patterns (pipeline/iterative/single-agent)
- **`emitHandoff()` method on SessionManager** — exposes pulse emission to discord.ts without leaking the emitter

## Context
Addresses yama-kei/pulse#50 — Pulse was showing all agents as `unknown` because `session_start` events lacked `agent_name`, and couldn't detect handoff patterns because no `agent_handoff` events existed.

## Test plan
- [x] `npm test` — all 550 tests pass
- [x] New tests for `agent_handoff` event emission (pulse-events + session-manager)
- [x] New tests for `agentName` in `sessionStart` (with and without agent key)
- [x] New test for `emitHandoff` method
- [ ] Manual: run MPG session with agent handoffs, verify `~/.pulse/events/mpg-sessions.jsonl` contains `agent_handoff` events and `session_start` events with `agent_name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)