### PR TITLE
feat(dashboard): link session labels to Discord threads

### DIFF
--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -266,7 +266,10 @@ function refresh() {
           var projName = resolveProjectNameFromDir(s.projectDir || s.cwd, dirToNameMap) || (projectNameMap && projectNameMap[pkParts[0]] ? projectNameMap[pkParts[0]] : null) || pkParts[0];
           var role = pkParts.length > 1 ? pkParts[1] : '';
           var sessionLabel = projName && shortId ? (role ? projName + '/' + shortId + '/' + role : projName + '/' + shortId) : (shortId || '—');
-          h += '<tr><td><span class="clickable-id" style="cursor:pointer;text-decoration:underline dotted" title="Click to copy: ' + escapeHtml(sid) + '" onclick="copyToClipboard(\\'' + escapeHtml(sid) + '\\', this)">' + escapeHtml(sessionLabel) + '</span></td><td>' + sessionStatus(s) + '</td><td>' + formatDuration(s.createdAt) + '</td><td>' + formatAgo(s.lastActivity) + '</td></tr>';
+          var labelHtml = s.sourceUrl
+            ? '<a href="' + escapeHtml(s.sourceUrl) + '" target="_blank" rel="noopener" style="color:#58a6ff;text-decoration:underline">' + escapeHtml(sessionLabel) + '</a>'
+            : '<span class="clickable-id" style="cursor:pointer;text-decoration:underline dotted" title="Click to copy: ' + escapeHtml(sid) + '" onclick="copyToClipboard(\\'' + escapeHtml(sid) + '\\', this)">' + escapeHtml(sessionLabel) + '</span>';
+          h += '<tr><td>' + labelHtml + '</td><td>' + sessionStatus(s) + '</td><td>' + formatDuration(s.createdAt) + '</td><td>' + formatAgo(s.lastActivity) + '</td></tr>';
         }
         h += '</table>';
         st.innerHTML = h;
@@ -873,10 +876,15 @@ export function createDashboardServer(
     }
 
     if (pathname === '/api/status') {
+      const sessions = sessionManager.listSessions().map((s) => {
+        const threadId = s.projectKey.includes(':') ? s.projectKey.split(':')[0] : s.projectKey;
+        const sourceUrl = s.guildId ? `https://discord.com/channels/${s.guildId}/${threadId}` : undefined;
+        return { ...s, sourceUrl };
+      });
       const body = JSON.stringify({
         version,
         health: getHealthData(),
-        sessions: sessionManager.listSessions(),
+        sessions,
         projects: getProjectsData(),
       });
       res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -427,6 +427,7 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
           worktree: replyChannel.isThread() ? true : undefined,
           systemPrompt,
           extraArgs: toolArgs.length > 0 ? toolArgs : undefined,
+          guildId: message.guildId ?? undefined,
         },
       );
 

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -15,13 +15,14 @@ export interface SessionInfo {
   queueLength: number;
   createdAt: number;
   processing: boolean;
+  guildId?: string;
 }
 
 /** Callback invoked when an orphaned tmux session produces a result on startup recovery. */
 export type OrphanResultCallback = (projectKey: string, result: ClaudeResult) => void;
 
 export interface SessionManager {
-  send(projectKey: string, cwd: string, prompt: string, opts?: { worktree?: boolean; systemPrompt?: string; timeoutMs?: number; extraArgs?: string[] }): Promise<ClaudeResult>;
+  send(projectKey: string, cwd: string, prompt: string, opts?: { worktree?: boolean; systemPrompt?: string; timeoutMs?: number; extraArgs?: string[]; guildId?: string }): Promise<ClaudeResult>;
   getSession(projectKey: string): SessionInfo | undefined;
   listSessions(): SessionInfo[];
   clearSession(projectKey: string): boolean;
@@ -37,6 +38,7 @@ interface InternalSession {
   cwd: string;
   projectDir: string | undefined;
   worktreePath: string | undefined;
+  guildId: string | undefined;
   lastActivity: number;
   createdAt: number;
   messageCount: number;
@@ -108,6 +110,7 @@ export function createSessionManager(defaults: {
           lastActivity: s.lastActivity,
           worktreePath: s.worktreePath,
           projectDir: s.projectDir,
+          guildId: s.guildId,
         });
       }
     }
@@ -242,7 +245,7 @@ export function createSessionManager(defaults: {
     session.processing = false;
   }
 
-  function getOrCreateSession(projectKey: string, cwd: string, useWorktree?: boolean): InternalSession {
+  function getOrCreateSession(projectKey: string, cwd: string, useWorktree?: boolean, guildId?: string): InternalSession {
     let session = sessions.get(projectKey);
     if (session && session.restored && !session.resumeEmitted && pulseEmitter && session.sessionId) {
       session.resumeEmitted = true;
@@ -258,6 +261,7 @@ export function createSessionManager(defaults: {
       let restoredSessionId: string | undefined;
       let restoredWorktreePath: string | undefined;
       let restoredLastActivity: number | undefined;
+      let restoredGuildId: string | undefined;
       if (store) {
         const persisted = store.load();
         const entry = persisted.get(projectKey);
@@ -265,6 +269,7 @@ export function createSessionManager(defaults: {
           restoredSessionId = entry.sessionId;
           restoredWorktreePath = entry.worktreePath;
           restoredLastActivity = entry.lastActivity;
+          restoredGuildId = entry.guildId;
         }
       }
 
@@ -289,6 +294,7 @@ export function createSessionManager(defaults: {
         cwd: effectiveCwd,
         projectDir,
         worktreePath,
+        guildId: guildId ?? restoredGuildId,
         lastActivity: Date.now(),
         createdAt: Date.now(),
         messageCount: 0,
@@ -337,6 +343,7 @@ export function createSessionManager(defaults: {
         cwd: entry.cwd,
         projectDir: entry.projectDir,
         worktreePath: entry.worktreePath,
+        guildId: entry.guildId,
         lastActivity: entry.lastActivity,
         createdAt: entry.lastActivity,
         messageCount: 0,
@@ -356,8 +363,8 @@ export function createSessionManager(defaults: {
   }
 
   return {
-    send(projectKey: string, cwd: string, prompt: string, opts?: { worktree?: boolean; systemPrompt?: string; timeoutMs?: number; extraArgs?: string[] }): Promise<ClaudeResult> {
-      const session = getOrCreateSession(projectKey, cwd, opts?.worktree);
+    send(projectKey: string, cwd: string, prompt: string, opts?: { worktree?: boolean; systemPrompt?: string; timeoutMs?: number; extraArgs?: string[]; guildId?: string }): Promise<ClaudeResult> {
+      const session = getOrCreateSession(projectKey, cwd, opts?.worktree, opts?.guildId);
       return new Promise<ClaudeResult>((resolve, reject) => {
         session.queue.push({ prompt, systemPrompt: opts?.systemPrompt, timeoutMs: opts?.timeoutMs, extraArgs: opts?.extraArgs, resolve, reject });
         processQueue(session);
@@ -376,6 +383,7 @@ export function createSessionManager(defaults: {
         queueLength: session.queue.length,
         createdAt: session.createdAt,
         processing: session.processing,
+        guildId: session.guildId,
       };
     },
 
@@ -389,6 +397,7 @@ export function createSessionManager(defaults: {
         queueLength: s.queue.length,
         createdAt: s.createdAt,
         processing: s.processing,
+        guildId: s.guildId,
       }));
     },
 

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -8,6 +8,7 @@ export interface PersistedSession {
   lastActivity: number;
   worktreePath?: string;
   projectDir?: string;
+  guildId?: string;
 }
 
 export interface SessionStore {


### PR DESCRIPTION
## Summary
- Captures `guildId` from Discord messages and passes it through `sessionManager.send()` → `InternalSession` → `PersistedSession`
- Dashboard `/api/status` builds `sourceUrl` (`https://discord.com/channels/{guildId}/{threadId}`) for sessions with a guildId
- Frontend renders session labels as clickable `<a>` links (opens in new tab) when `sourceUrl` is present; plain text when absent
- `guildId` persists across restarts via session-store

## Files changed
- `src/discord.ts` — pass `message.guildId` in send options
- `src/session-manager.ts` — add `guildId` to `SessionInfo`, `InternalSession`, persist/restore it
- `src/session-store.ts` — add `guildId` to `PersistedSession`
- `src/dashboard-server.ts` — build `sourceUrl`, render as clickable link in frontend

## Test plan
- [x] All 104 existing tests pass (session-manager, session-store, discord, dashboard-server)
- [ ] Manual: verify Discord sessions show clickable link in dashboard
- [ ] Manual: verify non-Discord sessions show plain text (no link)
- [ ] Manual: verify guildId survives gateway restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)