### PR TITLE
fix(dashboard): show ongoing sessions on Timeline (#174)

### DIFF
--- a/src/activity-engine.ts
+++ b/src/activity-engine.ts
@@ -126,7 +126,7 @@ export interface ActivityEngine {
     segments: Array<{
       start: string;
       end: string;
-      state: 'processing' | 'idle';
+      state: 'processing' | 'idle' | 'pending';
       token_count?: number;
       token_rate?: number;
     }>;
@@ -287,7 +287,7 @@ export function createActivityEngine(filePath?: string): ActivityEngine {
         else sessionMap.set(e.session_id, [e]);
       }
 
-      type Segment = { start: string; end: string; state: 'processing' | 'idle'; token_count?: number; token_rate?: number };
+      type Segment = { start: string; end: string; state: 'processing' | 'idle' | 'pending'; token_count?: number; token_rate?: number };
       const result: Array<{
         session_id: string;
         thread_id: string;
@@ -366,6 +366,18 @@ export function createActivityEngine(filePath?: string): ActivityEngine {
             if (segments.length > 0 || sessionEvents.length > 1) {
               segments.push({ start: segmentStart, end: lastEvent.timestamp, state: currentState });
             }
+          }
+        }
+
+        // Synthesize a 'pending' segment for active sessions that have no processing segments.
+        // This covers sessions with only session_start (or only idle segments) so they
+        // remain visible on the timeline instead of being filtered out.
+        if (segments.length === 0 ||
+            !segments.some(s => s.state === 'processing')) {
+          const hasNoEnd = lastEvent.event_type !== 'session_end' && lastEvent.event_type !== 'session_idle';
+          if (hasNoEnd) {
+            const nowIso = new Date().toISOString();
+            segments.push({ start: lastEvent.timestamp, end: nowIso, state: 'pending' });
           }
         }
 

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -379,9 +379,9 @@ function refreshTimeline() {
       var dpr = window.devicePixelRatio || 1;
       var containerW = canvas.parentElement.clientWidth - 32;
 
-      // Filter out sessions with only idle segments (no processing)
+      // Filter out sessions with only idle segments (no processing or pending)
       var activeSessions = sessions ? sessions.filter(function(s) {
-        return s.segments.some(function(seg) { return seg.state === 'processing'; });
+        return s.segments.some(function(seg) { return seg.state === 'processing' || seg.state === 'pending'; });
       }) : [];
 
       var LABEL_W = 180;
@@ -593,7 +593,9 @@ function refreshTimeline() {
             var x2 = timeToX(segEnd);
             var w = Math.max(x2 - x1, 1);
 
-            ctx.fillStyle = seg.state === 'processing' ? tokenRateColor(seg.token_rate || 0) : '#484f58';
+            ctx.fillStyle = seg.state === 'processing' ? tokenRateColor(seg.token_rate || 0)
+              : seg.state === 'pending' ? '#d29922'
+              : '#484f58';
             ctx.fillRect(x1, barY, w, barH);
 
             _tlHitRects.push({ x: x1, y: barY, w: w, h: barH, label: sess.label, state: seg.state, start: seg.start, end: seg.end, token_count: seg.token_count || 0, token_rate: seg.token_rate || 0 });


### PR DESCRIPTION
## Summary
- Synthesize a `pending` segment for active sessions that lack processing segments, so they appear on the Timeline instead of being silently filtered out
- Pending segments render in amber (`#d29922`) to visually distinguish from processing (green intensity) and idle (dark gray)
- Expands the frontend filter to include `pending` segments alongside `processing`

Closes #174

## Test plan
- [ ] Start a session that only has `session_start` (no `message_routed` yet) — verify it appears on the Timeline with an amber bar
- [ ] Hover over the amber bar — tooltip should show "Pending" with duration
- [ ] Sessions with processing segments still render normally (green intensity)
- [ ] Ended/idle sessions without processing segments do **not** appear (no false positives)
- [ ] Verify across all time ranges (1h, 3h, 12h, 24h, 7d, 30d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)