### PR TITLE
fix(tmux): write command to script file for large system prompts

### DIFF
--- a/src/runtimes/tmux-runtime.ts
+++ b/src/runtimes/tmux-runtime.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, statSync, rmSync, existsSync, watch } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, existsSync, watch, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { buildClaudeArgs, parseClaudeJsonOutput, friendlyError } from '../claude-cli.js';
 import type { AgentRuntime, SpawnOpts } from '../agent-runtime.js';
@@ -64,13 +64,18 @@ export class TmuxRuntime implements AgentRuntime {
     const timeoutSec = Math.ceil((timeoutMs + bufferMs) / 1000);
     const command = `timeout ${timeoutSec} claude ${escapedArgs.join(' ')} > ${shellEscape(outPath)} 2> ${shellEscape(errPath)}`;
 
+    // Write command to a script file to avoid tmux command-length limits
+    // (system prompts with life context can exceed tmux's buffer).
+    const scriptPath = join(outDir, 'run.sh');
+    writeFileSync(scriptPath, `#!/bin/sh\n${command}\n`, { mode: 0o755 });
+
     // Kill any stale session with the same name
     if (sessionExists(tmuxName)) {
       killSession(tmuxName);
     }
 
-    // Launch in tmux
-    createSession(tmuxName, command, { cwd: opts.cwd });
+    // Launch the script in tmux (short command string regardless of prompt size)
+    createSession(tmuxName, scriptPath, { cwd: opts.cwd });
 
     // Wait for Claude to finish by polling for tmux session exit + output file
     return this._waitForResult(tmuxName, sessionKey, outPath, errPath, timeoutMs);

--- a/tests/tmux-runtime.test.ts
+++ b/tests/tmux-runtime.test.ts
@@ -15,6 +15,7 @@ vi.mock('node:fs', async () => {
     ...actual,
     mkdirSync: vi.fn(),
     readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
     existsSync: vi.fn().mockReturnValue(false),
     statSync: vi.fn(),
     rmSync: vi.fn(),
@@ -90,15 +91,15 @@ describe('TmuxRuntime', () => {
       );
       expect(mockCreateSession).toHaveBeenCalledWith(
         expect.stringMatching(/^mpg-/),
-        expect.stringContaining('claude'),
+        expect.stringContaining('run.sh'),
         expect.objectContaining({ cwd: '/tmp/project' }),
       );
       expect(result.text).toBe('Hello from tmux');
       expect(result.sessionId).toBe('tmux-session-123');
 
-      // Verify timeout wrapper: timeoutMs=5000 + 5min buffer = 305s
-      const command = mockCreateSession.mock.calls[0][1] as string;
-      expect(command).toMatch(/^timeout 305 claude /);
+      // Verify script contains timeout wrapper: timeoutMs=5000 + 5min buffer = 305s
+      const scriptContent = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      expect(scriptContent).toMatch(/^#!\/bin\/sh\ntimeout 305 claude /);
     });
 
     it('uses default timeout (20min + 5min buffer = 1500s) when timeoutMs is omitted', async () => {
@@ -108,8 +109,8 @@ describe('TmuxRuntime', () => {
 
       await runtime.spawn({ ...spawnOpts, timeoutMs: undefined });
 
-      const command = mockCreateSession.mock.calls[0][1] as string;
-      expect(command).toMatch(/^timeout 1500 claude /);
+      const scriptContent = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      expect(scriptContent).toMatch(/^#!\/bin\/sh\ntimeout 1500 claude /);
     });
 
     it('kills stale tmux session before launching new one', async () => {


### PR DESCRIPTION
## Summary
- System prompts with life context data (~6KB+) cause `tmux new-session` to fail because the full command string exceeds tmux's command buffer
- Fix: write the command to a `run.sh` script file in the session output directory, then launch that script in tmux
- The tmux command stays short (`/tmp/mpg-sessions/.../run.sh`) regardless of prompt size

## Test plan
- [x] All 13 tmux-runtime tests pass (updated to verify script content)
- [x] Full suite: 1072/1072 pass
- [ ] Deploy and verify `!life-work` with life context loads successfully

Refs: yama-kei/ayumi#13

🤖 Generated with [Claude Code](https://claude.com/claude-code)