### PR TITLE
Add tier-3 approval flow with !curator commands

### DIFF
--- a/src/agent-dispatch.ts
+++ b/src/agent-dispatch.ts
@@ -11,7 +11,7 @@ export interface AgentMention {
 
 /** Built-in command names that take precedence over agent shorthand (!<agent>). */
 const BUILT_IN_COMMANDS = new Set([
-  'help', 'sessions', 'session', 'kill', 'restart', 'agents', 'ask',
+  'help', 'sessions', 'session', 'kill', 'restart', 'agents', 'ask', 'curator',
 ]);
 
 /**

--- a/src/ayumi/curator-commands.ts
+++ b/src/ayumi/curator-commands.ts
@@ -1,0 +1,132 @@
+/**
+ * Discord commands for managing tier-3 content approval.
+ *
+ * Commands:
+ *   !curator pending              — list pending tier-3 topics
+ *   !curator approve <topic|all>  — approve and write to Drive
+ *   !curator reject <topic>       — remove from manifest without writing
+ */
+
+import type { BrokerClient } from '../broker-client.js';
+import { createBrokerClientFromEnv } from '../broker-client.js';
+import { ensureLifeContextFolders, type FolderMap, type TopicName } from './life-context-setup.js';
+import {
+  readPendingManifest,
+  removeFromManifest,
+  writePendingManifest,
+} from './drive-writer.js';
+
+/**
+ * Handle a `!curator <subcommand>` message.
+ * Returns a formatted Discord response string, or null if the command is not recognized.
+ */
+export async function handleCuratorCommand(text: string): Promise<string | null> {
+  const match = text.match(/^!curator\s+(\S+)(?:\s+(.*))?$/i);
+  if (!match) return null;
+
+  const subcommand = match[1].toLowerCase();
+  const arg = match[2]?.trim() ?? '';
+
+  let client: BrokerClient;
+  let folderMap: FolderMap;
+  try {
+    client = createBrokerClientFromEnv();
+    folderMap = await ensureLifeContextFolders(client);
+  } catch (err) {
+    return `Failed to connect to Drive: ${err instanceof Error ? err.message : String(err)}`;
+  }
+
+  switch (subcommand) {
+    case 'pending':
+      return handlePending(client, folderMap);
+    case 'approve':
+      if (!arg) return 'Usage: `!curator approve <topic>` or `!curator approve all`';
+      return handleApprove(client, folderMap, arg);
+    case 'reject':
+      if (!arg) return 'Usage: `!curator reject <topic>`';
+      return handleReject(client, folderMap, arg);
+    default:
+      return [
+        `Unknown curator command: \`${subcommand}\``,
+        'Available: `!curator pending`, `!curator approve <topic|all>`, `!curator reject <topic>`',
+      ].join('\n');
+  }
+}
+
+async function handlePending(
+  client: BrokerClient,
+  folderMap: FolderMap,
+): Promise<string> {
+  const manifest = await readPendingManifest(client, folderMap);
+  if (!manifest || Object.keys(manifest.topics).length === 0) {
+    return 'No pending tier-3 topics awaiting review.';
+  }
+
+  const lines = ['**Pending tier-3 topics for review:**', ''];
+  for (const [topic, entry] of Object.entries(manifest.topics)) {
+    lines.push(`**${topic}** — ${entry.fileCount} file(s), ${entry.totalSize} bytes`);
+    lines.push(`> ${entry.preview.slice(0, 200)}${entry.preview.length > 200 ? '...' : ''}`);
+    lines.push('');
+  }
+  lines.push(`Created: ${manifest.createdAt}`);
+  lines.push('');
+  lines.push('Use `!curator approve <topic>` or `!curator approve all` to write to Drive.');
+  lines.push('Use `!curator reject <topic>` to discard.');
+
+  return lines.join('\n');
+}
+
+async function handleApprove(
+  client: BrokerClient,
+  folderMap: FolderMap,
+  arg: string,
+): Promise<string> {
+  const manifest = await readPendingManifest(client, folderMap);
+  if (!manifest || Object.keys(manifest.topics).length === 0) {
+    return 'No pending topics to approve.';
+  }
+
+  const topicsToApprove = arg.toLowerCase() === 'all'
+    ? Object.keys(manifest.topics)
+    : [arg.toLowerCase()];
+
+  const results: string[] = [];
+
+  for (const topic of topicsToApprove) {
+    if (!(topic in manifest.topics)) {
+      results.push(`**${topic}** — not found in pending manifest, skipped.`);
+      continue;
+    }
+
+    const folderId = folderMap.topics[topic as TopicName];
+    if (!folderId) {
+      results.push(`**${topic}** — no Drive folder found, skipped.`);
+      continue;
+    }
+
+    const entry = manifest.topics[topic];
+
+    // Write the full summary.md (stored in manifest at approval-skip time)
+    await client.driveWrite('summary.md', entry.summaryContent, 'text', folderId);
+    delete manifest.topics[topic];
+    results.push(`**${topic}** — approved and written to Drive.`);
+  }
+
+  // Update or clear manifest
+  await writePendingManifest(client, folderMap, manifest);
+
+  return results.join('\n');
+}
+
+async function handleReject(
+  client: BrokerClient,
+  folderMap: FolderMap,
+  arg: string,
+): Promise<string> {
+  const topic = arg.toLowerCase();
+  const removed = await removeFromManifest(client, folderMap, topic);
+  if (!removed) {
+    return `Topic \`${topic}\` not found in pending manifest.`;
+  }
+  return `**${topic}** — rejected and removed from pending review.`;
+}

--- a/src/ayumi/drive-writer.ts
+++ b/src/ayumi/drive-writer.ts
@@ -1,6 +1,7 @@
 import type { BrokerClient } from '../broker-client.js';
 import type { FolderMap } from './life-context-setup.js';
 import type { TopicSummaryResult } from './topic-summarizer.js';
+import type { TopicName } from './life-context-setup.js';
 
 export interface DriveWriterOptions {
   approved?: boolean;
@@ -13,6 +14,21 @@ export interface DriveWriteResult {
   skippedReason?: string;
 }
 
+export interface PendingTopicEntry {
+  fileCount: number;
+  totalSize: number;
+  preview: string;
+  /** Full summary content, stored so approval can write without re-running the pipeline. */
+  summaryContent: string;
+}
+
+export interface PendingReviewManifest {
+  createdAt: string;
+  topics: Record<string, PendingTopicEntry>;
+}
+
+const MANIFEST_NAME = 'pending-review.json';
+
 export async function writeTopicToDrive(
   client: BrokerClient,
   folderMap: FolderMap,
@@ -21,8 +37,9 @@ export async function writeTopicToDrive(
 ): Promise<DriveWriteResult> {
   const folderId = folderMap.topics[summary.topic];
 
-  // Tier 3 requires explicit approval
+  // Tier 3 requires explicit approval — write manifest instead
   if (summary.requiresApproval && !options?.approved) {
+    await addToPendingManifest(client, folderMap, summary);
     return {
       topic: summary.topic,
       written: false,
@@ -54,4 +71,86 @@ export async function writeTopicToDrive(
     written: true,
     filesWritten,
   };
+}
+
+/**
+ * Read the pending-review manifest from the curator meta folder.
+ * Returns null if no manifest exists.
+ */
+export async function readPendingManifest(
+  client: BrokerClient,
+  folderMap: FolderMap,
+): Promise<PendingReviewManifest | null> {
+  try {
+    const listing = await client.driveList(folderMap.meta, MANIFEST_NAME);
+    const file = listing.files.find((f) => f.name === MANIFEST_NAME);
+    if (!file) return null;
+    const content = await client.driveRead(file.file_id);
+    return JSON.parse(content.content) as PendingReviewManifest;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write (or overwrite) the pending-review manifest to the curator meta folder.
+ * If the manifest has no topics left, deletes it instead.
+ */
+export async function writePendingManifest(
+  client: BrokerClient,
+  folderMap: FolderMap,
+  manifest: PendingReviewManifest | null,
+): Promise<void> {
+  if (!manifest || Object.keys(manifest.topics).length === 0) {
+    // Write empty content to effectively clear; Drive doesn't have a delete via broker
+    // but an empty manifest signals "nothing pending"
+    await client.driveWrite(MANIFEST_NAME, '{}', 'text', folderMap.meta);
+    return;
+  }
+  await client.driveWrite(MANIFEST_NAME, JSON.stringify(manifest, null, 2), 'text', folderMap.meta);
+}
+
+/**
+ * Add a tier-3 topic summary to the pending-review manifest.
+ */
+async function addToPendingManifest(
+  client: BrokerClient,
+  folderMap: FolderMap,
+  summary: TopicSummaryResult,
+): Promise<void> {
+  const existing = await readPendingManifest(client, folderMap);
+  const manifest: PendingReviewManifest = existing ?? {
+    createdAt: new Date().toISOString(),
+    topics: {},
+  };
+
+  const fileCount = Object.values(summary.files).filter(Boolean).length;
+  const totalSize = Object.values(summary.files)
+    .filter((v): v is string => typeof v === 'string')
+    .reduce((sum, content) => sum + content.length, 0);
+  const preview = summary.files.summary.slice(0, 200);
+
+  manifest.topics[summary.topic] = {
+    fileCount,
+    totalSize,
+    preview,
+    summaryContent: summary.files.summary,
+  };
+  await writePendingManifest(client, folderMap, manifest);
+}
+
+/**
+ * Remove a topic from the pending manifest.
+ * Returns true if the topic was found and removed.
+ */
+export async function removeFromManifest(
+  client: BrokerClient,
+  folderMap: FolderMap,
+  topic: string,
+): Promise<boolean> {
+  const manifest = await readPendingManifest(client, folderMap);
+  if (!manifest || !(topic in manifest.topics)) return false;
+  delete manifest.topics[topic];
+  await writePendingManifest(client, folderMap, manifest);
+  return true;
 }

--- a/src/ayumi/index.ts
+++ b/src/ayumi/index.ts
@@ -23,3 +23,8 @@ export async function getAgentContext(agentName: string): Promise<string | null>
  * Loaded lazily so the preset registry can merge them at startup.
  */
 export { AYUMI_PRESETS } from './presets.js';
+
+/**
+ * Curator approval commands for tier-3 content.
+ */
+export { handleCuratorCommand } from './curator-commands.js';

--- a/src/ayumi/presets.ts
+++ b/src/ayumi/presets.ts
@@ -139,7 +139,7 @@ export const AYUMI_PRESETS: Record<string, AgentConfig> = {
       'If an item spans multiple topics, assign to the primary topic. If unclear, prefer the lower-sensitivity topic.',
       '',
       'When you finish processing, report: items fetched, items excluded, items per topic, files written.',
-      'If you need PM review of tier 3 content, write HANDOFF @pm: followed by the approval request.',
+      'For tier 3 content (finance, health): do NOT write files directly. Instead, a pending-review manifest will be written to Drive automatically. The user can then review and approve via `!curator pending`, `!curator approve <topic>`, or `!curator reject <topic>`.',
     ].join('\n'),
   },
 };

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -10,6 +10,7 @@ import { hasAllowedRole } from './role-check.js';
 import { createRateLimiter } from './rate-limiter.js';
 import { downloadAttachments, buildAttachmentPrompt, type AttachmentConfig, DEFAULT_ATTACHMENT_CONFIG } from './attachments.js';
 import type { AgentConfig } from './config.js';
+import { handleCuratorCommand } from './ayumi/curator-commands.js';
 
 // Ayumi life-context module — optional, gracefully absent
 let getAgentContext: (agentName: string) => Promise<string | null> = async () => null;
@@ -188,6 +189,9 @@ export function handleCommand(
       '`!restart <name>` — reset a session (fresh context, keeps worktree)',
       '`!kill <name>` — force-close a project session',
       '`!agents` — list available agents for the current project',
+      '`!curator pending` — list pending tier-3 topics for review',
+      '`!curator approve <topic|all>` — approve tier-3 content to Drive',
+      '`!curator reject <topic>` — discard pending tier-3 content',
       '`!help` — show this message',
     ].join('\n');
   }
@@ -244,6 +248,15 @@ export function createDiscordBot(router: Router, sessionManager: SessionManager,
       const parentId = message.channel.isThread() ? message.channel.parentId ?? undefined : undefined;
       const resolved = router.resolve(message.channelId, parentId);
       if (resolved) {
+        // Handle async !curator commands before sync handleCommand
+        if (message.content.match(/^!curator\b/i)) {
+          const curatorResponse = await handleCuratorCommand(message.content);
+          if (curatorResponse) {
+            await message.channel.send(curatorResponse);
+            return;
+          }
+        }
+
         const response = handleCommand(message.content, config, sessionManager, {
           channelId: resolved.channelId,
           projectName: resolved.name,

--- a/tests/ayumi/curator-commands.test.ts
+++ b/tests/ayumi/curator-commands.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleCuratorCommand } from '../../src/ayumi/curator-commands.js';
+import type { BrokerClient } from '../../src/broker-client.js';
+
+// Mock broker-client module
+const mockDriveWrite = vi.fn().mockResolvedValue({ file_id: 'new-id', name: 'test', mime_type: 'text/plain', web_view_link: null });
+const mockDriveList = vi.fn();
+const mockDriveRead = vi.fn();
+const mockDriveSearch = vi.fn();
+const mockDriveCreateFolder = vi.fn();
+
+vi.mock('../../src/broker-client.js', () => ({
+  createBrokerClientFromEnv: () => ({
+    health: vi.fn(),
+    gmailSearch: vi.fn(),
+    gmailMessages: vi.fn(),
+    calendarEvents: vi.fn(),
+    driveRead: mockDriveRead,
+    driveWrite: mockDriveWrite,
+    driveSearch: mockDriveSearch,
+    driveCreateFolder: mockDriveCreateFolder,
+    driveList: mockDriveList,
+  }),
+}));
+
+// Mock life-context-setup to return a fixed folder map
+vi.mock('../../src/ayumi/life-context-setup.js', () => ({
+  TOPIC_FOLDERS: ['work', 'travel', 'finance', 'health', 'social', 'hobbies'],
+  ensureLifeContextFolders: vi.fn().mockResolvedValue({
+    root: 'root-id',
+    topics: { work: 'work-id', travel: 'travel-id', finance: 'finance-id', health: 'health-id', social: 'social-id', hobbies: 'hobbies-id' },
+    meta: 'meta-id',
+  }),
+}));
+
+const sampleManifest = {
+  createdAt: '2026-04-01T10:00:00.000Z',
+  topics: {
+    finance: {
+      fileCount: 1,
+      totalSize: 150,
+      preview: '# Finance — Summary\n\n3 item(s) found in this sensitive category.',
+      summaryContent: '# Finance — Summary\n\n3 item(s) found in this sensitive category.\n\nThis is a high-sensitivity topic (tier 3). Only aggregate counts are included.\n\n- 2 email(s), 1 calendar event(s)\n- Date range: 2026-03-01 to 2026-03-28\n',
+    },
+    health: {
+      fileCount: 1,
+      totalSize: 120,
+      preview: '# Health — Summary\n\n2 item(s) found in this sensitive category.',
+      summaryContent: '# Health — Summary\n\n2 item(s) found in this sensitive category.\n\nThis is a high-sensitivity topic (tier 3). Only aggregate counts are included.\n\n- 1 email(s), 1 calendar event(s)\n- Date range: 2026-03-05 to 2026-03-20\n',
+    },
+  },
+};
+
+function setupManifestInDrive(manifest: object | null) {
+  if (manifest) {
+    mockDriveList.mockResolvedValue({
+      files: [{ file_id: 'manifest-id', name: 'pending-review.json', mime_type: 'text/plain', size_bytes: 100, modified_at: '2026-04-01T10:00:00Z', web_view_link: null }],
+    });
+    mockDriveRead.mockResolvedValue({
+      name: 'pending-review.json',
+      mime_type: 'text/plain',
+      content: JSON.stringify(manifest),
+    });
+  } else {
+    mockDriveList.mockResolvedValue({ files: [] });
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('handleCuratorCommand', () => {
+  it('returns null for non-curator commands', async () => {
+    const result = await handleCuratorCommand('!help');
+    expect(result).toBeNull();
+  });
+
+  it('returns error for unknown subcommand', async () => {
+    setupManifestInDrive(null);
+    const result = await handleCuratorCommand('!curator foobar');
+    expect(result).toContain('Unknown curator command');
+  });
+
+  describe('!curator pending', () => {
+    it('reports no pending topics when manifest is empty', async () => {
+      setupManifestInDrive(null);
+      const result = await handleCuratorCommand('!curator pending');
+      expect(result).toContain('No pending tier-3 topics');
+    });
+
+    it('reports no pending topics when manifest has empty topics', async () => {
+      setupManifestInDrive({ createdAt: '2026-04-01T10:00:00Z', topics: {} });
+      const result = await handleCuratorCommand('!curator pending');
+      expect(result).toContain('No pending tier-3 topics');
+    });
+
+    it('lists pending topics with previews', async () => {
+      setupManifestInDrive(sampleManifest);
+      const result = await handleCuratorCommand('!curator pending');
+      expect(result).toContain('**finance**');
+      expect(result).toContain('**health**');
+      expect(result).toContain('1 file(s)');
+      expect(result).toContain('!curator approve');
+    });
+  });
+
+  describe('!curator approve', () => {
+    it('returns usage when no topic given', async () => {
+      const result = await handleCuratorCommand('!curator approve');
+      expect(result).toContain('Usage');
+    });
+
+    it('reports nothing to approve when manifest is empty', async () => {
+      setupManifestInDrive(null);
+      const result = await handleCuratorCommand('!curator approve finance');
+      expect(result).toContain('No pending topics to approve');
+    });
+
+    it('approves a single topic and writes to Drive', async () => {
+      setupManifestInDrive(sampleManifest);
+      const result = await handleCuratorCommand('!curator approve finance');
+
+      expect(result).toContain('**finance** — approved');
+      // Should write summary.md to finance folder
+      expect(mockDriveWrite).toHaveBeenCalledWith(
+        'summary.md',
+        sampleManifest.topics.finance.summaryContent,
+        'text',
+        'finance-id',
+      );
+      // Should update manifest (removing finance, keeping health)
+      expect(mockDriveWrite).toHaveBeenCalledWith(
+        'pending-review.json',
+        expect.stringContaining('"health"'),
+        'text',
+        'meta-id',
+      );
+    });
+
+    it('approves all topics', async () => {
+      setupManifestInDrive(sampleManifest);
+      const result = await handleCuratorCommand('!curator approve all');
+
+      expect(result).toContain('**finance** — approved');
+      expect(result).toContain('**health** — approved');
+      // Should write both summaries
+      expect(mockDriveWrite).toHaveBeenCalledWith('summary.md', sampleManifest.topics.finance.summaryContent, 'text', 'finance-id');
+      expect(mockDriveWrite).toHaveBeenCalledWith('summary.md', sampleManifest.topics.health.summaryContent, 'text', 'health-id');
+      // Manifest should be cleared (empty)
+      expect(mockDriveWrite).toHaveBeenCalledWith('pending-review.json', '{}', 'text', 'meta-id');
+    });
+
+    it('reports unknown topic gracefully', async () => {
+      setupManifestInDrive(sampleManifest);
+      const result = await handleCuratorCommand('!curator approve travel');
+      expect(result).toContain('not found in pending manifest');
+    });
+  });
+
+  describe('!curator reject', () => {
+    it('returns usage when no topic given', async () => {
+      const result = await handleCuratorCommand('!curator reject');
+      expect(result).toContain('Usage');
+    });
+
+    it('rejects a topic and removes from manifest', async () => {
+      setupManifestInDrive(sampleManifest);
+      const result = await handleCuratorCommand('!curator reject finance');
+
+      expect(result).toContain('**finance** — rejected');
+      // Should update manifest without finance
+      expect(mockDriveWrite).toHaveBeenCalledWith(
+        'pending-review.json',
+        expect.stringContaining('"health"'),
+        'text',
+        'meta-id',
+      );
+    });
+
+    it('reports unknown topic', async () => {
+      setupManifestInDrive(null);
+      const result = await handleCuratorCommand('!curator reject travel');
+      expect(result).toContain('not found in pending manifest');
+    });
+  });
+});

--- a/tests/ayumi/drive-writer.test.ts
+++ b/tests/ayumi/drive-writer.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
-import { writeTopicToDrive, type DriveWriterOptions } from '../../src/ayumi/drive-writer.js';
+import {
+  writeTopicToDrive,
+  readPendingManifest,
+  writePendingManifest,
+  removeFromManifest,
+  type DriveWriterOptions,
+  type PendingReviewManifest,
+} from '../../src/ayumi/drive-writer.js';
 import type { BrokerClient } from '../../src/broker-client.js';
 import type { FolderMap } from '../../src/ayumi/life-context-setup.js';
 import type { TopicSummaryResult } from '../../src/ayumi/topic-summarizer.js';
@@ -64,8 +71,10 @@ describe('writeTopicToDrive', () => {
     expect(client.driveWrite).toHaveBeenCalledWith('summary.md', summary.files.summary, 'text', 'finance-id');
   });
 
-  it('skips write for tier 3 topics when not approved', async () => {
-    const client = mockClient();
+  it('skips topic write for tier 3 when not approved, but writes manifest', async () => {
+    const client = mockClient({
+      driveList: vi.fn().mockResolvedValue({ files: [] }),
+    });
     const summary: TopicSummaryResult = {
       topic: 'health',
       files: { summary: '# Health — Summary\n\n...' },
@@ -77,11 +86,16 @@ describe('writeTopicToDrive', () => {
 
     expect(result.written).toBe(false);
     expect(result.skippedReason).toBe('approval_required');
-    expect(client.driveWrite).not.toHaveBeenCalled();
+    // Should NOT write summary.md to the topic folder
+    expect(client.driveWrite).not.toHaveBeenCalledWith('summary.md', expect.anything(), expect.anything(), 'health-id');
+    // Should write pending-review manifest
+    expect(client.driveWrite).toHaveBeenCalledWith('pending-review.json', expect.stringContaining('"health"'), 'text', 'meta-id');
   });
 
   it('defaults to not approved for tier 3 topics', async () => {
-    const client = mockClient();
+    const client = mockClient({
+      driveList: vi.fn().mockResolvedValue({ files: [] }),
+    });
     const summary: TopicSummaryResult = {
       topic: 'health',
       files: { summary: '# Health — Summary\n\n...' },
@@ -92,5 +106,128 @@ describe('writeTopicToDrive', () => {
     const result = await writeTopicToDrive(client, testFolderMap, summary);
 
     expect(result.written).toBe(false);
+  });
+
+  it('writes pending-review manifest when tier 3 is skipped', async () => {
+    const client = mockClient({
+      driveList: vi.fn().mockResolvedValue({ files: [] }),
+    });
+    const summary: TopicSummaryResult = {
+      topic: 'finance',
+      files: { summary: '# Finance — Summary\n\nSensitive data here.' },
+      requiresApproval: true,
+      itemCount: 3,
+    };
+
+    await writeTopicToDrive(client, testFolderMap, summary);
+
+    // Should have written the manifest to the meta folder
+    expect(client.driveWrite).toHaveBeenCalledWith(
+      'pending-review.json',
+      expect.stringContaining('"finance"'),
+      'text',
+      'meta-id',
+    );
+  });
+});
+
+describe('readPendingManifest', () => {
+  it('returns null when no manifest file exists', async () => {
+    const client = mockClient({
+      driveList: vi.fn().mockResolvedValue({ files: [] }),
+    });
+    const result = await readPendingManifest(client, testFolderMap);
+    expect(result).toBeNull();
+  });
+
+  it('reads and parses existing manifest', async () => {
+    const manifest: PendingReviewManifest = {
+      createdAt: '2026-04-01T10:00:00Z',
+      topics: {
+        finance: { fileCount: 1, totalSize: 100, preview: 'preview text', summaryContent: 'full content' },
+      },
+    };
+    const client = mockClient({
+      driveList: vi.fn().mockResolvedValue({
+        files: [{ file_id: 'manifest-id', name: 'pending-review.json', mime_type: 'text/plain', size_bytes: 100, modified_at: '2026-04-01T10:00:00Z', web_view_link: null }],
+      }),
+      driveRead: vi.fn().mockResolvedValue({ name: 'pending-review.json', mime_type: 'text/plain', content: JSON.stringify(manifest) }),
+    });
+
+    const result = await readPendingManifest(client, testFolderMap);
+    expect(result).toEqual(manifest);
+  });
+
+  it('returns null on error', async () => {
+    const client = mockClient({
+      driveList: vi.fn().mockRejectedValue(new Error('network error')),
+    });
+    const result = await readPendingManifest(client, testFolderMap);
+    expect(result).toBeNull();
+  });
+});
+
+describe('writePendingManifest', () => {
+  it('writes manifest to meta folder', async () => {
+    const client = mockClient();
+    const manifest: PendingReviewManifest = {
+      createdAt: '2026-04-01T10:00:00Z',
+      topics: { finance: { fileCount: 1, totalSize: 100, preview: 'preview', summaryContent: 'full' } },
+    };
+
+    await writePendingManifest(client, testFolderMap, manifest);
+    expect(client.driveWrite).toHaveBeenCalledWith(
+      'pending-review.json',
+      JSON.stringify(manifest, null, 2),
+      'text',
+      'meta-id',
+    );
+  });
+
+  it('writes empty object when manifest has no topics', async () => {
+    const client = mockClient();
+    await writePendingManifest(client, testFolderMap, { createdAt: '2026-04-01T10:00:00Z', topics: {} });
+    expect(client.driveWrite).toHaveBeenCalledWith('pending-review.json', '{}', 'text', 'meta-id');
+  });
+
+  it('writes empty object when manifest is null', async () => {
+    const client = mockClient();
+    await writePendingManifest(client, testFolderMap, null);
+    expect(client.driveWrite).toHaveBeenCalledWith('pending-review.json', '{}', 'text', 'meta-id');
+  });
+});
+
+describe('removeFromManifest', () => {
+  it('removes topic and updates manifest', async () => {
+    const manifest: PendingReviewManifest = {
+      createdAt: '2026-04-01T10:00:00Z',
+      topics: {
+        finance: { fileCount: 1, totalSize: 100, preview: 'p', summaryContent: 'full' },
+        health: { fileCount: 1, totalSize: 80, preview: 'p2', summaryContent: 'full2' },
+      },
+    };
+    const client = mockClient({
+      driveList: vi.fn().mockResolvedValue({
+        files: [{ file_id: 'manifest-id', name: 'pending-review.json', mime_type: 'text/plain', size_bytes: 100, modified_at: '2026-04-01T10:00:00Z', web_view_link: null }],
+      }),
+      driveRead: vi.fn().mockResolvedValue({ name: 'pending-review.json', mime_type: 'text/plain', content: JSON.stringify(manifest) }),
+    });
+
+    const result = await removeFromManifest(client, testFolderMap, 'finance');
+    expect(result).toBe(true);
+    expect(client.driveWrite).toHaveBeenCalledWith(
+      'pending-review.json',
+      expect.stringContaining('"health"'),
+      'text',
+      'meta-id',
+    );
+  });
+
+  it('returns false when topic not in manifest', async () => {
+    const client = mockClient({
+      driveList: vi.fn().mockResolvedValue({ files: [] }),
+    });
+    const result = await removeFromManifest(client, testFolderMap, 'travel');
+    expect(result).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Replace broken `HANDOFF @pm` mechanism for tier-3 (finance/health) data with a pending-review manifest + Discord commands
- When tier-3 summaries are produced, `pending-review.json` is written to Drive's `_meta/` folder instead of emitting a HANDOFF
- Users manage approvals via `!curator pending`, `!curator approve <topic|all>`, and `!curator reject <topic>`
- Manifest includes topic name, file count, size, preview (~200 chars), and full summary content for writing on approval

## Files changed
| File | Change |
|------|--------|
| `src/ayumi/presets.ts` | Replaced HANDOFF @pm instruction with manifest-based approval guidance |
| `src/ayumi/drive-writer.ts` | Added manifest read/write/update functions; tier-3 skip now writes manifest |
| `src/ayumi/curator-commands.ts` | **New** — `!curator pending/approve/reject` command handlers |
| `src/ayumi/index.ts` | Export `handleCuratorCommand` |
| `src/discord.ts` | Wire up `!curator` as async command before sync `handleCommand` |
| `src/agent-dispatch.ts` | Add `curator` to `BUILT_IN_COMMANDS` to prevent agent dispatch collision |
| `tests/ayumi/drive-writer.test.ts` | Updated existing test + added manifest read/write/remove tests |
| `tests/ayumi/curator-commands.test.ts` | **New** — 13 tests for pending/approve/reject flows |

## Test plan
- [x] All 1094 existing tests pass (73 files)
- [x] 13 new curator-commands tests cover pending/approve/reject flows
- [x] 8 new drive-writer tests cover manifest read/write/remove logic
- [x] Existing tier-3 skip test updated to verify manifest is written
- [ ] Manual: trigger curator pipeline, verify `pending-review.json` appears in Drive
- [ ] Manual: run `!curator pending` in Discord, verify topics listed
- [ ] Manual: run `!curator approve finance`, verify summary.md written to Drive

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)