### PR TITLE
fix(tmux): forward BROKER_* env vars to Claude CLI sessions

### DIFF
--- a/src/runtimes/tmux-runtime.ts
+++ b/src/runtimes/tmux-runtime.ts
@@ -66,8 +66,14 @@ export class TmuxRuntime implements AgentRuntime {
 
     // Write command to a script file to avoid tmux command-length limits
     // (system prompts with life context can exceed tmux's buffer).
+    // Forward BROKER_* env vars so the Claude CLI process can access the
+    // HouseholdOS broker API (used by curator and other Ayumi agents).
+    const envExports = ['BROKER_URL', 'BROKER_API_SECRET', 'BROKER_TENANT_ID', 'BROKER_ACTOR_ID']
+      .filter((k) => process.env[k])
+      .map((k) => `export ${k}=${shellEscape(process.env[k]!)}`)
+      .join('\n');
     const scriptPath = join(outDir, 'run.sh');
-    writeFileSync(scriptPath, `#!/bin/sh\n${command}\n`, { mode: 0o755 });
+    writeFileSync(scriptPath, `#!/bin/sh\n${envExports ? envExports + '\n' : ''}${command}\n`, { mode: 0o755 });
 
     // Kill any stale session with the same name
     if (sessionExists(tmuxName)) {


### PR DESCRIPTION
## Summary
- MPG loads broker credentials via dotenv, but Claude CLI in tmux runs in a fresh shell
- The curator agent fails with "Broker env vars not configured" because BROKER_* vars aren't inherited
- Fix: export BROKER_* vars in the run.sh script so all agents can access the broker API

## Test plan
- [x] 1119/1119 tests pass
- [ ] Run curator and verify it can access broker API (no "env vars not configured" error)

Refs: yama-kei/ayumi#13

🤖 Generated with [Claude Code](https://claude.com/claude-code)