### PR TITLE
Add web URL and local file ingestion to curator pipeline

### DIFF
--- a/src/ayumi/extraction-pipeline.ts
+++ b/src/ayumi/extraction-pipeline.ts
@@ -10,7 +10,7 @@ export interface ExtractionOptions {
 
 export interface ClassifiedItem {
   sourceId: string;
-  source: 'gmail' | 'calendar';
+  source: 'gmail' | 'calendar' | 'web' | 'local';
   topic: TopicName;
   tier: 1 | 2 | 3;
   subject: string;

--- a/src/ayumi/local-reader.ts
+++ b/src/ayumi/local-reader.ts
@@ -1,0 +1,134 @@
+/**
+ * Reads local markdown files and converts them to ClassifiedItems.
+ * Used by the curator pipeline to ingest locally authored content.
+ *
+ * Directory source: CURATOR_LOCAL_DIR env var or explicit parameter.
+ * Reads all .md files (non-recursive) from the directory.
+ */
+
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { join, basename } from 'node:path';
+import type { ClassifiedItem } from './extraction-pipeline.js';
+import { classifyTopic } from './extraction-pipeline.js';
+
+const TOPIC_TIER_MAP = {
+  work: 2, travel: 1, finance: 3, health: 3, social: 2, hobbies: 1,
+} as const;
+
+/**
+ * Parse YAML frontmatter from a markdown file.
+ * Returns the frontmatter fields and the body (content after frontmatter).
+ */
+export function parseFrontmatter(content: string): {
+  fields: Record<string, string>;
+  body: string;
+} {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) return { fields: {}, body: content };
+
+  const fields: Record<string, string> = {};
+  for (const line of match[1].split('\n')) {
+    const kv = line.match(/^(\w[\w_-]*):\s*(.+)$/);
+    if (kv) {
+      fields[kv[1]] = kv[2].replace(/^["']|["']$/g, '');
+    }
+  }
+
+  return { fields, body: match[2] };
+}
+
+/**
+ * Extract the title from a markdown file.
+ * Priority: frontmatter `title`, first `# heading`, filename.
+ */
+export function extractTitle(content: string, filename: string): string {
+  const { fields, body } = parseFrontmatter(content);
+
+  if (fields.title) return fields.title;
+
+  const headingMatch = body.match(/^#\s+(.+)$/m);
+  if (headingMatch) return headingMatch[1].trim();
+
+  return basename(filename, '.md').replace(/[-_]/g, ' ');
+}
+
+/**
+ * Extract the date from a markdown file.
+ * Priority: frontmatter `date`, filename date pattern (YYYY-MM-DD), file mtime.
+ */
+export function extractDate(
+  content: string,
+  filename: string,
+  mtime: Date,
+): string {
+  const { fields } = parseFrontmatter(content);
+
+  if (fields.date) return fields.date;
+
+  // Try YYYY-MM-DD pattern in filename
+  const dateMatch = filename.match(/(\d{4}-\d{2}-\d{2})/);
+  if (dateMatch) return `${dateMatch[1]}T00:00:00Z`;
+
+  return mtime.toISOString();
+}
+
+/**
+ * Read all .md files from a directory and return ClassifiedItems.
+ * Non-recursive — only reads files directly in the given directory.
+ */
+export async function readAndClassifyLocalFiles(
+  dirPath: string,
+): Promise<ClassifiedItem[]> {
+  const items: ClassifiedItem[] = [];
+
+  let entries: string[];
+  try {
+    entries = await readdir(dirPath);
+  } catch (err) {
+    console.warn(`[local-reader] Cannot read directory ${dirPath}:`, err);
+    return [];
+  }
+
+  const mdFiles = entries.filter((f) => f.endsWith('.md'));
+
+  for (const filename of mdFiles) {
+    const filePath = join(dirPath, filename);
+    try {
+      const fileStat = await stat(filePath);
+      if (!fileStat.isFile()) continue;
+
+      const content = await readFile(filePath, 'utf-8');
+      const { body } = parseFrontmatter(content);
+      const title = extractTitle(content, filename);
+      const date = extractDate(content, filename, fileStat.mtime);
+      const snippet = body.replace(/^#.*\n+/, '').trim().slice(0, 200);
+
+      const topic = classifyTopic(title, snippet, filename);
+
+      items.push({
+        sourceId: filePath,
+        source: 'local',
+        topic,
+        tier: TOPIC_TIER_MAP[topic],
+        subject: title,
+        date,
+        from: filePath,
+        snippet,
+        body,
+      });
+    } catch (err) {
+      console.warn(`[local-reader] Failed to read ${filePath}:`, err);
+    }
+  }
+
+  return items;
+}
+
+/**
+ * Resolve the local source directory.
+ * Priority: explicit param > CURATOR_LOCAL_DIR env.
+ */
+export function resolveLocalDir(dirPath?: string): string | null {
+  if (dirPath) return dirPath;
+  return process.env.CURATOR_LOCAL_DIR ?? null;
+}

--- a/src/ayumi/topic-summarizer.ts
+++ b/src/ayumi/topic-summarizer.ts
@@ -159,7 +159,8 @@ function generateTimeline(title: string, items: ClassifiedItem[], entityNames: S
 
   for (const item of sorted) {
     const date = item.date.split('T')[0];
-    const source = item.source === 'gmail' ? '📧' : '📅';
+    const sourceEmoji: Record<string, string> = { gmail: '📧', calendar: '📅', web: '🌐', local: '📄' };
+    const source = sourceEmoji[item.source] ?? '📎';
     const line = `- ${date} ${source} ${item.subject}`;
     lines.push(applyWikilinks(line, entityNames));
   }

--- a/src/ayumi/web-fetcher.ts
+++ b/src/ayumi/web-fetcher.ts
@@ -1,0 +1,189 @@
+/**
+ * Fetches and extracts article text from web URLs.
+ * Used by the curator pipeline to ingest authored content (blog posts, articles).
+ *
+ * URL sources can come from:
+ * - CURATOR_URLS env var (comma-separated)
+ * - $VAULT_PATH/_identity/authored-sources.md (one URL per line)
+ * - Direct function call with a URL list
+ */
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { ClassifiedItem } from './extraction-pipeline.js';
+import { classifyTopic } from './extraction-pipeline.js';
+
+const TOPIC_TIER_MAP = {
+  work: 2, travel: 1, finance: 3, health: 3, social: 2, hobbies: 1,
+} as const;
+
+/**
+ * Extract article title from HTML.
+ * Tries <title>, then first <h1>.
+ */
+export function extractTitle(html: string): string {
+  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  if (titleMatch) return titleMatch[1].trim().replace(/\s+/g, ' ');
+
+  const h1Match = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  if (h1Match) return stripTags(h1Match[1]).trim();
+
+  return 'Untitled';
+}
+
+/**
+ * Extract publication date from HTML meta tags.
+ * Looks for common meta date patterns.
+ */
+export function extractDate(html: string): string | null {
+  // <meta property="article:published_time" content="...">
+  const ogDate = html.match(/<meta\s+(?:property|name)="(?:article:published_time|date|DC\.date|publish[_-]?date)"[^>]*content="([^"]+)"/i);
+  if (ogDate) return ogDate[1];
+
+  // <time datetime="...">
+  const timeTag = html.match(/<time[^>]*datetime="([^"]+)"/i);
+  if (timeTag) return timeTag[1];
+
+  return null;
+}
+
+/**
+ * Strip HTML tags from a string.
+ */
+export function stripTags(html: string): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Extract article body text from HTML.
+ * Prefers <article> or <main> content, falls back to <body>.
+ */
+export function extractBody(html: string): string {
+  // Try <article> first
+  const articleMatch = html.match(/<article[^>]*>([\s\S]*?)<\/article>/i);
+  if (articleMatch) return stripTags(articleMatch[1]);
+
+  // Try <main>
+  const mainMatch = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i);
+  if (mainMatch) return stripTags(mainMatch[1]);
+
+  // Fall back to <body>
+  const bodyMatch = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+  if (bodyMatch) return stripTags(bodyMatch[1]);
+
+  return stripTags(html);
+}
+
+/**
+ * Load URL list from configured sources.
+ * Priority: explicit urls param > CURATOR_URLS env > authored-sources.md in vault.
+ */
+export async function loadUrlSources(
+  urls?: string[],
+  vaultPath?: string,
+): Promise<string[]> {
+  if (urls && urls.length > 0) return urls;
+
+  // Try CURATOR_URLS env var
+  const envUrls = process.env.CURATOR_URLS;
+  if (envUrls) {
+    return envUrls.split(',').map((u) => u.trim()).filter(Boolean);
+  }
+
+  // Try authored-sources.md in vault
+  if (vaultPath) {
+    try {
+      const content = await readFile(join(vaultPath, '_identity', 'authored-sources.md'), 'utf-8');
+      return parseUrlList(content);
+    } catch {
+      // File doesn't exist — no URLs
+    }
+  }
+
+  return [];
+}
+
+/**
+ * Parse a markdown file containing URLs (one per line, optionally in a list).
+ */
+export function parseUrlList(content: string): string[] {
+  return content
+    .split('\n')
+    .map((line) => line.replace(/^[-*]\s+/, '').trim())
+    .filter((line) => line.startsWith('http://') || line.startsWith('https://'));
+}
+
+export interface WebFetchResult {
+  url: string;
+  title: string;
+  date: string;
+  body: string;
+  snippet: string;
+}
+
+/**
+ * Fetch a single URL and extract article content.
+ * Uses native fetch (Node 18+).
+ */
+export async function fetchUrl(url: string): Promise<WebFetchResult> {
+  const response = await fetch(url, {
+    headers: { 'User-Agent': 'Ayumi-Curator/1.0' },
+    signal: AbortSignal.timeout(15000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} fetching ${url}`);
+  }
+
+  const html = await response.text();
+  const title = extractTitle(html);
+  const rawDate = extractDate(html);
+  const date = rawDate ?? new Date().toISOString();
+  const body = extractBody(html);
+  const snippet = body.slice(0, 200);
+
+  return { url, title, date, body, snippet };
+}
+
+/**
+ * Fetch multiple URLs and return ClassifiedItems.
+ * Errors on individual URLs are logged and skipped.
+ */
+export async function fetchAndClassifyUrls(
+  urls: string[],
+): Promise<ClassifiedItem[]> {
+  const items: ClassifiedItem[] = [];
+
+  for (const url of urls) {
+    try {
+      const result = await fetchUrl(url);
+      const topic = classifyTopic(result.title, result.snippet, url);
+      items.push({
+        sourceId: url,
+        source: 'web',
+        topic,
+        tier: TOPIC_TIER_MAP[topic],
+        subject: result.title,
+        date: result.date,
+        from: url,
+        snippet: result.snippet,
+        body: result.body,
+      });
+    } catch (err) {
+      console.warn(`[web-fetcher] Failed to fetch ${url}:`, err);
+    }
+  }
+
+  return items;
+}

--- a/tests/ayumi/local-reader.test.ts
+++ b/tests/ayumi/local-reader.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  parseFrontmatter,
+  extractTitle,
+  extractDate,
+  readAndClassifyLocalFiles,
+  resolveLocalDir,
+} from '../../src/ayumi/local-reader.js';
+import { mkdtemp, writeFile, rm, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+describe('parseFrontmatter', () => {
+  it('parses YAML frontmatter and returns fields + body', () => {
+    const content = '---\ntitle: My Post\ndate: 2026-03-15\n---\n# My Post\n\nContent here.';
+    const result = parseFrontmatter(content);
+    expect(result.fields.title).toBe('My Post');
+    expect(result.fields.date).toBe('2026-03-15');
+    expect(result.body).toContain('# My Post');
+    expect(result.body).toContain('Content here.');
+  });
+
+  it('returns empty fields and full body when no frontmatter', () => {
+    const content = '# No Frontmatter\n\nJust content.';
+    const result = parseFrontmatter(content);
+    expect(result.fields).toEqual({});
+    expect(result.body).toBe(content);
+  });
+
+  it('strips quotes from field values', () => {
+    const content = '---\ntitle: "Quoted Title"\ndate: \'2026-01-01\'\n---\nBody';
+    const result = parseFrontmatter(content);
+    expect(result.fields.title).toBe('Quoted Title');
+    expect(result.fields.date).toBe('2026-01-01');
+  });
+});
+
+describe('extractTitle', () => {
+  it('uses frontmatter title', () => {
+    expect(extractTitle('---\ntitle: FM Title\n---\n# H1 Title\nBody', 'file.md')).toBe('FM Title');
+  });
+
+  it('falls back to first heading', () => {
+    expect(extractTitle('# Heading Title\nBody', 'file.md')).toBe('Heading Title');
+  });
+
+  it('falls back to filename', () => {
+    expect(extractTitle('Just body text', 'my-cool-post.md')).toBe('my cool post');
+  });
+});
+
+describe('extractDate', () => {
+  it('uses frontmatter date', () => {
+    expect(extractDate('---\ndate: 2026-03-15\n---\nBody', 'file.md', new Date('2026-04-01')))
+      .toBe('2026-03-15');
+  });
+
+  it('extracts date from filename', () => {
+    const mtime = new Date('2026-04-01');
+    expect(extractDate('No frontmatter', '2026-02-20-my-post.md', mtime))
+      .toBe('2026-02-20T00:00:00Z');
+  });
+
+  it('falls back to mtime', () => {
+    const mtime = new Date('2026-04-01T12:00:00Z');
+    expect(extractDate('No date anywhere', 'untitled.md', mtime))
+      .toBe('2026-04-01T12:00:00.000Z');
+  });
+});
+
+describe('readAndClassifyLocalFiles', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'local-reader-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('reads .md files and classifies them', async () => {
+    await writeFile(
+      join(tempDir, 'tokyo-trip.md'),
+      '---\ntitle: My Tokyo Trip\ndate: 2026-02-15\n---\n# My Tokyo Trip\n\nI traveled to Tokyo and stayed at a hotel near the airport.',
+    );
+
+    const result = await readAndClassifyLocalFiles(tempDir);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('local');
+    expect(result[0].subject).toBe('My Tokyo Trip');
+    expect(result[0].topic).toBe('travel');
+    expect(result[0].date).toBe('2026-02-15');
+    expect(result[0].body).toContain('traveled to Tokyo');
+    expect(result[0].from).toContain('tokyo-trip.md');
+  });
+
+  it('reads multiple files', async () => {
+    await writeFile(join(tempDir, 'work.md'), '# Sprint Planning\n\nMeeting about the project.');
+    await writeFile(join(tempDir, 'hobby.md'), '# Weekend Hiking\n\nWent hiking in the mountains with yoga.');
+
+    const result = await readAndClassifyLocalFiles(tempDir);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.source)).toEqual(['local', 'local']);
+  });
+
+  it('skips non-.md files', async () => {
+    await writeFile(join(tempDir, 'notes.md'), '# Notes\n\nSome notes.');
+    await writeFile(join(tempDir, 'image.png'), 'binary data');
+    await writeFile(join(tempDir, 'data.json'), '{}');
+
+    const result = await readAndClassifyLocalFiles(tempDir);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].subject).toBe('Notes');
+  });
+
+  it('returns empty array for non-existent directory', async () => {
+    const result = await readAndClassifyLocalFiles('/nonexistent/dir/path');
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array for empty directory', async () => {
+    const emptyDir = await mkdtemp(join(tmpdir(), 'empty-'));
+    const result = await readAndClassifyLocalFiles(emptyDir);
+    expect(result).toEqual([]);
+    await rm(emptyDir, { recursive: true, force: true });
+  });
+
+  it('extracts snippet from body without heading', async () => {
+    await writeFile(
+      join(tempDir, 'post.md'),
+      '# Title\n\nThis is the actual content that should become the snippet. It goes on for a while.',
+    );
+
+    const result = await readAndClassifyLocalFiles(tempDir);
+    expect(result[0].snippet).toBe('This is the actual content that should become the snippet. It goes on for a while.');
+  });
+});
+
+describe('resolveLocalDir', () => {
+  it('returns explicit path', () => {
+    expect(resolveLocalDir('/my/dir')).toBe('/my/dir');
+  });
+
+  it('reads CURATOR_LOCAL_DIR env var', () => {
+    process.env.CURATOR_LOCAL_DIR = '/env/dir';
+    expect(resolveLocalDir()).toBe('/env/dir');
+    delete process.env.CURATOR_LOCAL_DIR;
+  });
+
+  it('returns null when nothing configured', () => {
+    delete process.env.CURATOR_LOCAL_DIR;
+    expect(resolveLocalDir()).toBeNull();
+  });
+});

--- a/tests/ayumi/web-fetcher.test.ts
+++ b/tests/ayumi/web-fetcher.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  extractTitle,
+  extractDate,
+  extractBody,
+  stripTags,
+  parseUrlList,
+  fetchAndClassifyUrls,
+  loadUrlSources,
+} from '../../src/ayumi/web-fetcher.js';
+import { mkdtemp, writeFile, rm, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+describe('extractTitle', () => {
+  it('extracts from <title> tag', () => {
+    const html = '<html><head><title>My Article Title</title></head><body></body></html>';
+    expect(extractTitle(html)).toBe('My Article Title');
+  });
+
+  it('falls back to <h1>', () => {
+    const html = '<html><body><h1>Heading Title</h1><p>Content</p></body></html>';
+    expect(extractTitle(html)).toBe('Heading Title');
+  });
+
+  it('returns Untitled when no title found', () => {
+    const html = '<html><body><p>Just content</p></body></html>';
+    expect(extractTitle(html)).toBe('Untitled');
+  });
+
+  it('strips tags inside <h1>', () => {
+    const html = '<html><body><h1><span>Rich</span> Title</h1></body></html>';
+    expect(extractTitle(html)).toBe('Rich Title');
+  });
+});
+
+describe('extractDate', () => {
+  it('extracts from article:published_time meta tag', () => {
+    const html = '<meta property="article:published_time" content="2026-03-15T10:00:00Z">';
+    expect(extractDate(html)).toBe('2026-03-15T10:00:00Z');
+  });
+
+  it('extracts from <time datetime="">', () => {
+    const html = '<time datetime="2026-01-20T09:00:00+09:00">Jan 20</time>';
+    expect(extractDate(html)).toBe('2026-01-20T09:00:00+09:00');
+  });
+
+  it('returns null when no date found', () => {
+    const html = '<html><body><p>No dates here</p></body></html>';
+    expect(extractDate(html)).toBeNull();
+  });
+});
+
+describe('extractBody', () => {
+  it('extracts from <article> tag', () => {
+    const html = '<html><body><nav>nav</nav><article><p>Article content</p></article><footer>foot</footer></body></html>';
+    expect(extractBody(html)).toBe('Article content');
+  });
+
+  it('falls back to <main> tag', () => {
+    const html = '<html><body><main><p>Main content here</p></main></body></html>';
+    expect(extractBody(html)).toBe('Main content here');
+  });
+
+  it('falls back to <body> tag', () => {
+    const html = '<html><body><p>Body content only</p></body></html>';
+    expect(extractBody(html)).toBe('Body content only');
+  });
+});
+
+describe('stripTags', () => {
+  it('removes HTML tags', () => {
+    expect(stripTags('<p>Hello <b>world</b></p>')).toBe('Hello world');
+  });
+
+  it('removes script and style tags', () => {
+    expect(stripTags('<script>alert("x")</script><style>body{}</style><p>Text</p>')).toBe('Text');
+  });
+
+  it('decodes HTML entities', () => {
+    expect(stripTags('&amp; &lt; &gt; &quot; &#39;')).toBe('& < > " \'');
+  });
+});
+
+describe('parseUrlList', () => {
+  it('parses plain URLs', () => {
+    const content = 'https://example.com/a\nhttps://example.com/b\n';
+    expect(parseUrlList(content)).toEqual(['https://example.com/a', 'https://example.com/b']);
+  });
+
+  it('parses markdown list format', () => {
+    const content = '- https://example.com/a\n- https://example.com/b\n* https://example.com/c\n';
+    expect(parseUrlList(content)).toEqual([
+      'https://example.com/a',
+      'https://example.com/b',
+      'https://example.com/c',
+    ]);
+  });
+
+  it('skips non-URL lines', () => {
+    const content = '# My URLs\n\nSome description\n- https://example.com/a\n- not a url\n';
+    expect(parseUrlList(content)).toEqual(['https://example.com/a']);
+  });
+});
+
+describe('loadUrlSources', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'web-fetcher-test-'));
+    delete process.env.CURATOR_URLS;
+  });
+
+  afterEach(async () => {
+    delete process.env.CURATOR_URLS;
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns explicit URLs when provided', async () => {
+    const result = await loadUrlSources(['https://a.com', 'https://b.com']);
+    expect(result).toEqual(['https://a.com', 'https://b.com']);
+  });
+
+  it('reads from CURATOR_URLS env var', async () => {
+    process.env.CURATOR_URLS = 'https://a.com,https://b.com';
+    const result = await loadUrlSources();
+    expect(result).toEqual(['https://a.com', 'https://b.com']);
+  });
+
+  it('reads from vault _identity/authored-sources.md', async () => {
+    await mkdir(join(tempDir, '_identity'), { recursive: true });
+    await writeFile(
+      join(tempDir, '_identity', 'authored-sources.md'),
+      '# Sources\n\n- https://blog.example.com/post-1\n- https://blog.example.com/post-2\n',
+    );
+    const result = await loadUrlSources(undefined, tempDir);
+    expect(result).toEqual([
+      'https://blog.example.com/post-1',
+      'https://blog.example.com/post-2',
+    ]);
+  });
+
+  it('returns empty when no sources configured', async () => {
+    const result = await loadUrlSources();
+    expect(result).toEqual([]);
+  });
+});
+
+describe('fetchAndClassifyUrls', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches URLs and returns classified items', async () => {
+    const mockHtml = `
+      <html>
+      <head><title>My Travel Blog Post</title></head>
+      <body>
+        <article>
+          <p>I went on a trip to Tokyo. The hotel was amazing and the flight was smooth.</p>
+        </article>
+      </body>
+      </html>
+    `;
+
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(mockHtml),
+    });
+
+    const result = await fetchAndClassifyUrls(['https://blog.example.com/tokyo-trip']);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('web');
+    expect(result[0].subject).toBe('My Travel Blog Post');
+    expect(result[0].topic).toBe('travel');
+    expect(result[0].from).toBe('https://blog.example.com/tokyo-trip');
+    expect(result[0].body).toContain('trip to Tokyo');
+  });
+
+  it('skips URLs that fail to fetch', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error('Network error'))
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve('<html><head><title>Good</title></head><body><article>Content</article></body></html>'),
+      });
+
+    const result = await fetchAndClassifyUrls([
+      'https://bad.example.com/broken',
+      'https://good.example.com/works',
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].subject).toBe('Good');
+  });
+
+  it('handles HTTP errors gracefully', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+    });
+
+    const result = await fetchAndClassifyUrls(['https://example.com/missing']);
+    expect(result).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/ayumi/web-fetcher.ts` — fetches web URLs, extracts article text from HTML, classifies into topics
- Adds `src/ayumi/local-reader.ts` — reads local `.md` files, parses frontmatter, classifies into topics
- Extends `ClassifiedItem.source` to `'gmail' | 'calendar' | 'web' | 'local'`
- Updates `topic-summarizer.ts` timeline emoji: 🌐 for web, 📄 for local
- Both adapters return `ClassifiedItem[]` that feed into the existing classify → summarize → vault-write pipeline

Part 2 of ayumi issue #34. Depends on PRs #197 and #198 (already merged).

## Configuration

| Variable | Default | Description |
|---|---|---|
| `CURATOR_URLS` | (unset) | Comma-separated list of URLs to fetch |
| `CURATOR_LOCAL_DIR` | (unset) | Directory path containing local `.md` files to ingest |

URLs can also be listed in `$VAULT_PATH/_identity/authored-sources.md` (one per line, markdown list format).

## New modules

### `web-fetcher.ts`
- `fetchAndClassifyUrls(urls)` — HTTP GET each URL, extract `<article>`/`<main>`/`<body>` text, strip HTML, parse title from `<title>`/`<h1>`, date from meta tags
- `loadUrlSources(urls?, vaultPath?)` — resolve URL list from params, env, or vault file
- `extractTitle()`, `extractDate()`, `extractBody()`, `stripTags()` — exported for testing

### `local-reader.ts`
- `readAndClassifyLocalFiles(dirPath)` — read all `.md` files, parse frontmatter for title/date, classify
- `parseFrontmatter(content)` — extract YAML frontmatter fields and body
- `resolveLocalDir(dirPath?)` — resolve directory from params or env

## Files changed (6)

- `src/ayumi/web-fetcher.ts` — **new** (189 lines)
- `src/ayumi/local-reader.ts` — **new** (134 lines)
- `src/ayumi/extraction-pipeline.ts` — extended `source` union type
- `src/ayumi/topic-summarizer.ts` — source emoji map for timeline
- `tests/ayumi/web-fetcher.test.ts` — **new** (23 tests)
- `tests/ayumi/local-reader.test.ts` — **new** (18 tests)

## Test plan

- [x] 152 ayumi tests pass (11 test files)
- [x] Web fetcher: HTML extraction, title/date parsing, URL list loading, error handling, classification
- [x] Local reader: frontmatter parsing, title/date extraction, directory reading, skip non-.md, error handling
- [x] Existing pipeline/summarizer/vault-writer tests unaffected
- [x] Full suite: 1201 pass, 2 fail (pre-existing tmux-runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)