### PR TITLE
fix: dynamic vault loading, remove dead contextPaths, increase size budget

### DIFF
--- a/src/ayumi/life-context-loader.ts
+++ b/src/ayumi/life-context-loader.ts
@@ -12,11 +12,12 @@
  *   life-finance → vault/topics/_sensitive/finance/
  *   life-health  → vault/topics/_sensitive/health/
  *
- * Files read: summary.md, timeline.md, entities.md (when they exist).
- * Missing files are skipped gracefully — a new or empty vault still works.
+ * Files read: all .md files in the topic directory (sorted alphabetically).
+ * Also loads _identity/writing-style.md for every topic agent.
+ * Missing files/directories are skipped gracefully — a new or empty vault still works.
  */
 
-import { readFile } from 'node:fs/promises';
+import { readFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { createBrokerClient, type BrokerClient, type DriveFile } from '../broker-client.js';
 import type { Topic } from 'ayumi';
@@ -32,11 +33,8 @@ const AGENT_TOPIC_MAP: Record<string, Topic> = {
 
 const SENSITIVE_TOPICS: Topic[] = ['finance', 'health'];
 
-/** Files to load from each topic folder, in order. */
-const TOPIC_FILES = ['summary.md', 'timeline.md', 'entities.md'];
-
 /** Maximum bytes of context content per topic before truncation. */
-export const DEFAULT_TOPIC_SIZE_BUDGET = 8 * 1024; // 8 KB
+export const DEFAULT_TOPIC_SIZE_BUDGET = 24 * 1024; // 24 KB
 
 /** Re-resolve folder IDs after this many milliseconds (5 minutes). */
 const FOLDER_CACHE_TTL_MS = 5 * 60 * 1000;
@@ -62,8 +60,9 @@ function topicVaultPath(vaultPath: string, topic: Topic): string {
 
 /**
  * Load life-context from the local vault filesystem.
- * Reads summary.md, timeline.md, entities.md from the topic directory.
- * Missing files are skipped gracefully.
+ * Reads all .md files from the topic directory (sorted alphabetically).
+ * Also appends _identity/writing-style.md if it exists.
+ * Missing directories are handled gracefully.
  */
 async function loadFromVault(
   vaultPath: string,
@@ -71,11 +70,24 @@ async function loadFromVault(
   sizeBudget: number,
 ): Promise<string | null> {
   const dir = topicVaultPath(vaultPath, topic);
+
+  // Dynamically discover all .md files in the topic directory
+  let mdFileNames: string[];
+  try {
+    const entries = await readdir(dir);
+    mdFileNames = entries.filter((f) => f.endsWith('.md')).sort();
+  } catch {
+    // Directory doesn't exist — skip gracefully
+    return null;
+  }
+
+  if (mdFileNames.length === 0) return null;
+
   const sections: string[] = [];
   let totalSize = 0;
   let filesIncluded = 0;
 
-  for (const fileName of TOPIC_FILES) {
+  for (const fileName of mdFileNames) {
     try {
       const content = await readFile(join(dir, fileName), 'utf-8');
       // Strip frontmatter for context injection (agents don't need YAML metadata)
@@ -84,7 +96,7 @@ async function loadFromVault(
       const sectionSize = new TextEncoder().encode(section).length;
 
       if (totalSize + sectionSize > sizeBudget && sections.length > 0) {
-        const remaining = TOPIC_FILES.length - filesIncluded;
+        const remaining = mdFileNames.length - filesIncluded;
         if (remaining > 0) {
           sections.push(`[truncated: ${remaining} file${remaining > 1 ? 's' : ''} omitted due to size budget]`);
         }
@@ -95,9 +107,23 @@ async function loadFromVault(
       totalSize += sectionSize;
       filesIncluded++;
     } catch {
-      // File doesn't exist — skip gracefully
       continue;
     }
+  }
+
+  // Append _identity/writing-style.md if it exists
+  try {
+    const writingStylePath = join(vaultPath, '_identity', 'writing-style.md');
+    const content = await readFile(writingStylePath, 'utf-8');
+    const stripped = content.replace(/^---[\s\S]*?---\n*/, '');
+    const section = `## writing-style.md\n${stripped}`;
+    const sectionSize = new TextEncoder().encode(section).length;
+
+    if (totalSize + sectionSize <= sizeBudget || sections.length === 0) {
+      sections.push(section);
+    }
+  } catch {
+    // writing-style.md doesn't exist — skip gracefully
   }
 
   if (sections.length === 0) return null;

--- a/src/ayumi/presets.ts
+++ b/src/ayumi/presets.ts
@@ -24,7 +24,6 @@ export const AYUMI_PRESETS: Record<string, AgentConfig> = {
       '- Social questions (friends, family, events, gatherings) → life-social',
       '- Hobby questions (sports, interests, activities) → life-hobbies',
       '- Ingestion requests (add this URL, import my blog, process this article, ingest content) → life-curator',
-      '- "What have I written about X?" → life-curator (knows all authored content)',
       '- Ambiguous or multi-topic → dispatch to all relevant agents',
       '',
       'Always pass the original question to the target agent. Do NOT rephrase or summarize.',
@@ -52,12 +51,6 @@ export const AYUMI_PRESETS: Record<string, AgentConfig> = {
       'To dispatch work to another agent, write HANDOFF @agent: followed by the task.',
       'To reference another agent conversationally, say "the travel agent" or "the router" — never write @agent outside of a HANDOFF command.',
     ].join('\n'),
-    contextPaths: [
-      '/life-context/work/summary.md',
-      '/life-context/work/timeline.md',
-      '/life-context/work/entities.md',
-      '/life-context/work/authored.md',
-    ],
   },
 
   'life-travel': {
@@ -78,12 +71,6 @@ export const AYUMI_PRESETS: Record<string, AgentConfig> = {
       'To dispatch work to another agent, write HANDOFF @agent: followed by the task.',
       'To reference another agent conversationally, say "the work agent" or "the router" — never write @agent outside of a HANDOFF command.',
     ].join('\n'),
-    contextPaths: [
-      '/life-context/travel/summary.md',
-      '/life-context/travel/timeline.md',
-      '/life-context/travel/entities.md',
-      '/life-context/travel/authored.md',
-    ],
   },
 
   'life-social': {
@@ -104,12 +91,6 @@ export const AYUMI_PRESETS: Record<string, AgentConfig> = {
       'To dispatch work to another agent, write HANDOFF @agent: followed by the task.',
       'To reference another agent conversationally, say "the work agent" or "the router" — never write @agent outside of a HANDOFF command.',
     ].join('\n'),
-    contextPaths: [
-      '/life-context/social/summary.md',
-      '/life-context/social/timeline.md',
-      '/life-context/social/entities.md',
-      '/life-context/social/authored.md',
-    ],
   },
 
   'life-hobbies': {
@@ -130,12 +111,6 @@ export const AYUMI_PRESETS: Record<string, AgentConfig> = {
       'To dispatch work to another agent, write HANDOFF @agent: followed by the task.',
       'To reference another agent conversationally, say "the work agent" or "the router" — never write @agent outside of a HANDOFF command.',
     ].join('\n'),
-    contextPaths: [
-      '/life-context/hobbies/summary.md',
-      '/life-context/hobbies/timeline.md',
-      '/life-context/hobbies/entities.md',
-      '/life-context/hobbies/authored.md',
-    ],
   },
 
   'life-finance': {
@@ -157,10 +132,6 @@ export const AYUMI_PRESETS: Record<string, AgentConfig> = {
       'To dispatch work to another agent, write HANDOFF @agent: followed by the task.',
       'To reference another agent conversationally, say "the work agent" or "the router" — never write @agent outside of a HANDOFF command.',
     ].join('\n'),
-    contextPaths: [
-      '/life-context/finance/summary.md',
-      '/life-context/finance/authored.md',
-    ],
   },
 
   'life-health': {
@@ -182,10 +153,6 @@ export const AYUMI_PRESETS: Record<string, AgentConfig> = {
       'To dispatch work to another agent, write HANDOFF @agent: followed by the task.',
       'To reference another agent conversationally, say "the work agent" or "the router" — never write @agent outside of a HANDOFF command.',
     ].join('\n'),
-    contextPaths: [
-      '/life-context/health/summary.md',
-      '/life-context/health/authored.md',
-    ],
   },
 
   'life-curator': {
@@ -318,13 +285,5 @@ export const AYUMI_PRESETS: Record<string, AgentConfig> = {
       '',
       'Error handling: Never silently fail. If a URL cannot be fetched or content cannot be extracted, report the specific issue and ask how to proceed.',
     ].join('\n'),
-    contextPaths: [
-      'topics/work/authored.md',
-      'topics/travel/authored.md',
-      'topics/_sensitive/finance/authored.md',
-      'topics/_sensitive/health/authored.md',
-      'topics/social/authored.md',
-      'topics/hobbies/authored.md',
-    ],
   },
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,6 @@ import { isValidLogLevel, type LogLevel } from './logger.js';
 export interface AgentConfig {
   role: string;
   prompt: string;
-  contextPaths?: string[];
   timeoutMs?: number;
 }
 

--- a/tests/ayumi/life-context-loader.test.ts
+++ b/tests/ayumi/life-context-loader.test.ts
@@ -109,11 +109,12 @@ describe('loadLifeContext — vault path', () => {
     expect(result).toBeNull();
   });
 
-  it('loads files from local vault when VAULT_PATH is set', async () => {
+  it('loads all .md files from local vault when VAULT_PATH is set', async () => {
     process.env.VAULT_PATH = tempDir;
     await setupVaultTopic('work', {
       'summary.md': '---\ntier: 2\n---\n# Work Summary\n\nProject updates.',
       'timeline.md': '---\ntier: 2\n---\n# Timeline\n\n- 2026-03-15 Meeting',
+      'authored.md': '# Authored\n\nBlog post about work.',
     });
 
     const result = await loadLifeContext('life-work');
@@ -123,6 +124,8 @@ describe('loadLifeContext — vault path', () => {
     expect(result).toContain('Project updates.');
     expect(result).toContain('## timeline.md');
     expect(result).toContain('Meeting');
+    expect(result).toContain('## authored.md');
+    expect(result).toContain('Blog post about work.');
     expect(result).toContain('--- END LIFE CONTEXT DATA ---');
   });
 
@@ -139,9 +142,8 @@ describe('loadLifeContext — vault path', () => {
     expect(result).toContain('Content.');
   });
 
-  it('skips missing files gracefully', async () => {
+  it('loads only the files that exist in the directory', async () => {
     process.env.VAULT_PATH = tempDir;
-    // Only summary.md exists — timeline.md and entities.md are missing
     await setupVaultTopic('work', {
       'summary.md': '# Work\n\nJust a summary.',
     });
@@ -149,8 +151,8 @@ describe('loadLifeContext — vault path', () => {
     const result = await loadLifeContext('life-work');
 
     expect(result).toContain('Just a summary.');
-    expect(result).not.toContain('## timeline.md');
-    expect(result).not.toContain('## entities.md');
+    // Only summary.md exists in the directory
+    expect(result).toContain('## summary.md');
   });
 
   it('returns null when topic directory does not exist', async () => {
@@ -171,21 +173,85 @@ describe('loadLifeContext — vault path', () => {
     expect(result).toContain('Abstract overview.');
   });
 
+  it('reads all .md files dynamically, not just hardcoded names', async () => {
+    process.env.VAULT_PATH = tempDir;
+    await setupVaultTopic('work', {
+      'summary.md': '# Summary\nOverview.',
+      'authored.md': '# Authored\nBlog posts.',
+      'weekly-report.md': '# Weekly\nReport data.',
+    });
+
+    const result = await loadLifeContext('life-work');
+
+    expect(result).toContain('## summary.md');
+    expect(result).toContain('## authored.md');
+    expect(result).toContain('## weekly-report.md');
+  });
+
+  it('loads _identity/writing-style.md and appends to context', async () => {
+    process.env.VAULT_PATH = tempDir;
+    await setupVaultTopic('work', {
+      'summary.md': '# Summary\nWork overview.',
+    });
+    // Create _identity/writing-style.md
+    await mkdir(join(tempDir, '_identity'), { recursive: true });
+    await writeFile(join(tempDir, '_identity', 'writing-style.md'), '---\ntype: identity\n---\n# Writing Style\n\nCasual, concise.');
+
+    const result = await loadLifeContext('life-work');
+
+    expect(result).toContain('## summary.md');
+    expect(result).toContain('## writing-style.md');
+    expect(result).toContain('Casual, concise.');
+    // Frontmatter should be stripped
+    expect(result).not.toContain('type: identity');
+  });
+
+  it('works without _identity/writing-style.md', async () => {
+    process.env.VAULT_PATH = tempDir;
+    await setupVaultTopic('work', {
+      'summary.md': '# Summary\nWork overview.',
+    });
+    // No _identity directory created
+
+    const result = await loadLifeContext('life-work');
+
+    expect(result).toContain('## summary.md');
+    expect(result).not.toContain('writing-style');
+  });
+
+  it('sorts vault files alphabetically', async () => {
+    process.env.VAULT_PATH = tempDir;
+    await setupVaultTopic('hobbies', {
+      'cycling.md': '# Cycling\nRoad biking.',
+      'authored.md': '# Authored\nBlog posts.',
+      'summary.md': '# Summary\nOverview.',
+    });
+
+    const result = await loadLifeContext('life-hobbies');
+
+    // Alphabetical: authored.md, cycling.md, summary.md
+    const authoredIdx = result!.indexOf('## authored.md');
+    const cyclingIdx = result!.indexOf('## cycling.md');
+    const summaryIdx = result!.indexOf('## summary.md');
+    expect(authoredIdx).toBeLessThan(cyclingIdx);
+    expect(cyclingIdx).toBeLessThan(summaryIdx);
+  });
+
   it('applies size budget when reading from vault', async () => {
     process.env.VAULT_PATH = tempDir;
     const largeContent = 'x'.repeat(200);
     await setupVaultTopic('work', {
-      'summary.md': `# Summary\n${largeContent}`,
-      'timeline.md': `# Timeline\n${largeContent}`,
-      'entities.md': `# Entities\n${largeContent}`,
+      'a-summary.md': `# Summary\n${largeContent}`,
+      'b-timeline.md': `# Timeline\n${largeContent}`,
+      'c-entities.md': `# Entities\n${largeContent}`,
     });
 
-    // Budget fits ~2 files
+    // Budget fits ~2 files (alphabetical order: a-summary, b-timeline, c-entities)
     const result = await loadLifeContext('life-work', 500);
 
-    expect(result).toContain('## summary.md');
-    expect(result).toContain('## timeline.md');
-    expect(result).not.toContain('## entities.md');
+    expect(result).toContain('## a-summary.md');
+    expect(result).toContain('## b-timeline.md');
+    expect(result).not.toContain('## c-entities.md');
     expect(result).toContain('[truncated');
   });
 });

--- a/tests/persona-presets.test.ts
+++ b/tests/persona-presets.test.ts
@@ -84,15 +84,8 @@ describe('persona-presets', () => {
   describe('life-curator', () => {
     const curator = PERSONA_PRESETS['life-curator'];
 
-    it('has contextPaths with all 6 topic authored.md files', () => {
-      expect(curator.contextPaths).toEqual([
-        'topics/work/authored.md',
-        'topics/travel/authored.md',
-        'topics/_sensitive/finance/authored.md',
-        'topics/_sensitive/health/authored.md',
-        'topics/social/authored.md',
-        'topics/hobbies/authored.md',
-      ]);
+    it('does not have contextPaths (dead code removed)', () => {
+      expect(curator).not.toHaveProperty('contextPaths');
     });
 
     it('references !curator commands for approval flow', () => {


### PR DESCRIPTION
## Summary

Fixes #57 — three related changes to improve life-context routing and loading:

- **Remove misrouted curator rule**: "What have I written about X?" queries now route to topic agents via existing topic-matching rules instead of the curator
- **Dynamic vault loading**: `loadFromVault()` reads all `.md` files from the topic directory via `readdir()` instead of a hardcoded 3-file list (`summary.md`, `timeline.md`, `entities.md`). Also appends `_identity/writing-style.md` to every topic agent's context
- **Dead code cleanup**: Remove `contextPaths` from all presets and the `AgentConfig` interface (nothing reads it at runtime)
- **Size budget increase**: `DEFAULT_TOPIC_SIZE_BUDGET` raised from 8KB to 24KB to accommodate topics with many files (hobbies has 14)

## Files changed

- `src/ayumi/presets.ts` — remove curator routing rule, remove all `contextPaths`
- `src/config.ts` — remove `contextPaths` from `AgentConfig` interface
- `src/ayumi/life-context-loader.ts` — dynamic file discovery, writing-style injection, 24KB budget
- `tests/ayumi/life-context-loader.test.ts` — 4 new tests (dynamic discovery, writing-style, alphabetical ordering, no writing-style fallback)
- `tests/persona-presets.test.ts` — update curator contextPaths test

## Test plan

- [x] All 23 life-context-loader tests pass (including 4 new)
- [x] All 15 persona-presets tests pass
- [ ] Manual: verify "What have I written about cycling?" routes to life-hobbies, not life-curator
- [ ] Manual: verify vault with >3 files per topic loads all of them

🤖 Generated with [Claude Code](https://claude.com/claude-code)