### PR TITLE
feat(mpg): on-demand life-context loading for topic agents

### DIFF
--- a/docs/superpowers/plans/2026-04-20-on-demand-life-context.md
+++ b/docs/superpowers/plans/2026-04-20-on-demand-life-context.md
@@ -1,0 +1,623 @@
+# On-Demand Life-Context Loading — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the 24 KB pre-loaded vault block for topic agents (`@life-hobbies` etc.) with a lightweight index plus topic-scoped `Read`/`Grep`/`Glob` tools, so agents can fetch only the files they need and large files like `mountains.md` (107 KB) become reachable.
+
+**Architecture:** `loadLifeContext(agentName)` keeps its signature but now returns an **index** — `summary.md` content (if present) plus a file listing with per-file size + frontmatter description — instead of concatenated file bodies. A new `getLifeContextToolArgs(agentName)` returns scoped `--allowed-tools` patterns like `Read(<vault>/topics/<topic>/**)` that the Discord/Slack adapters merge into the CLI invocation. The agent uses the built-in `Read`/`Grep`/`Glob` tools; Claude CLI's permission matcher enforces the topic boundary.
+
+**Tech Stack:** TypeScript, Node.js `fs/promises`, Vitest. No new dependencies.
+
+---
+
+## File Structure
+
+### Modified
+- `src/ayumi/life-context-loader.ts` — reshape `loadFromVault` + `loadFromDrive` to produce an index; add `getLifeContextToolArgs()` exported helper
+- `src/ayumi/index.ts` — re-export `getLifeContextToolArgs`
+- `src/discord.ts` — call `getLifeContextToolArgs` in the agent invocation path; merge into `toolArgs`
+- `src/slack.ts` — same
+- `tests/ayumi/life-context-loader.test.ts` — update existing tests (they assert old concatenation behavior) and add new scoping/traversal coverage
+
+### Not touched
+- `src/ayumi/presets.ts` — persona prompts already mention fetching context as needed; no changes required
+- `src/claude-cli.ts` / `buildToolArgs` — left alone; the life-context path computes and passes a full `--allowed-tools` list that replaces the gateway default for life-* agents only
+
+---
+
+## Tasks
+
+### Task 1: New index-building helper (pure function)
+
+**Files:**
+- Modify: `src/ayumi/life-context-loader.ts`
+- Test: `tests/ayumi/life-context-loader.test.ts`
+
+- [ ] **Step 1.1: Write failing test for buildVaultIndex — basic file listing**
+
+Add a new `describe('buildVaultIndex')` block at the end of the existing file:
+
+```typescript
+import { buildVaultIndex } from '../../src/ayumi/life-context-loader.js';
+
+describe('buildVaultIndex — local filesystem', () => {
+  it('lists .md files in a topic directory with size and description', async () => {
+    await setupVaultTopic('hobbies', {
+      'summary.md': '---\ndescription: hobbies overview\n---\n# Hobbies\n\nOverview.',
+      'mountains.md': '---\ndescription: mountaineering log 2004-2019\n---\n# Mountains\n\nBody.',
+      'cycling.md': '# Cycling\n\nNo frontmatter.',
+    });
+
+    const index = await buildVaultIndex(tempDir, 'hobbies');
+    expect(index).not.toBeNull();
+    expect(index!.summary).toContain('# Hobbies');
+    expect(index!.files.map((f) => f.name).sort()).toEqual(['cycling.md', 'mountains.md', 'summary.md']);
+    const mountains = index!.files.find((f) => f.name === 'mountains.md')!;
+    expect(mountains.description).toBe('mountaineering log 2004-2019');
+    expect(mountains.sizeBytes).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 1.2: Run the test, confirm it fails (buildVaultIndex is not exported)**
+
+```bash
+cd /home/yamakei/Documents/multi-project-gateway/.worktrees/1496034088690257952-engineer
+npx vitest run tests/ayumi/life-context-loader.test.ts -t "lists .md files"
+```
+
+Expected: FAIL with "buildVaultIndex is not a function" or import error.
+
+- [ ] **Step 1.3: Implement buildVaultIndex in life-context-loader.ts**
+
+Add below the existing `topicVaultPath` helper:
+
+```typescript
+export interface VaultIndexFile {
+  name: string;
+  sizeBytes: number;
+  description: string | null;
+}
+
+export interface VaultIndex {
+  summary: string | null;
+  files: VaultIndexFile[];
+}
+
+function parseFrontmatterDescription(content: string): string | null {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+  const descLine = match[1].split('\n').find((l) => /^description:\s*/.test(l));
+  if (!descLine) return null;
+  return descLine.replace(/^description:\s*/, '').trim().replace(/^["']|["']$/g, '') || null;
+}
+
+function stripFrontmatter(content: string): string {
+  return content.replace(/^---[\s\S]*?---\n*/, '');
+}
+
+export async function buildVaultIndex(vaultPath: string, topic: Topic): Promise<VaultIndex | null> {
+  const dir = topicVaultPath(vaultPath, topic);
+  let names: string[];
+  try {
+    const entries = await readdir(dir);
+    names = entries.filter((f) => f.endsWith('.md')).sort();
+  } catch {
+    return null;
+  }
+  if (names.length === 0) return null;
+
+  const files: VaultIndexFile[] = [];
+  let summary: string | null = null;
+
+  for (const name of names) {
+    try {
+      const content = await readFile(join(dir, name), 'utf-8');
+      const description = parseFrontmatterDescription(content);
+      const sizeBytes = Buffer.byteLength(content, 'utf-8');
+      files.push({ name, sizeBytes, description });
+      if (name === 'summary.md') {
+        summary = stripFrontmatter(content);
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return { summary, files };
+}
+```
+
+- [ ] **Step 1.4: Run the test, confirm it passes**
+
+```bash
+npx vitest run tests/ayumi/life-context-loader.test.ts -t "lists .md files"
+```
+
+Expected: PASS.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(ayumi): add buildVaultIndex helper for on-demand context"
+```
+
+---
+
+### Task 2: Reshape loadLifeContext to return index block
+
+The existing `loadLifeContext` returns the full concatenated content. We change it to return a compact index string (summary + file listing) that the agent sees in its system prompt. All existing tests that assert on concatenated file bodies must be updated.
+
+**Files:**
+- Modify: `src/ayumi/life-context-loader.ts`
+- Modify: `tests/ayumi/life-context-loader.test.ts`
+
+- [ ] **Step 2.1: Write the index-block assertion test**
+
+Replace the existing `it('loads all .md files from local vault when VAULT_PATH is set', ...)` test with an equivalent for the new shape:
+
+```typescript
+it('emits an index block listing topic files when VAULT_PATH is set', async () => {
+  process.env.VAULT_PATH = tempDir;
+  await setupVaultTopic('work', {
+    'summary.md': '---\ntier: 2\ndescription: work overview\n---\n# Work Summary\n\nProject updates.',
+    'timeline.md': '---\ntier: 2\n---\n# Timeline\n\n- 2026-03-15 Meeting',
+    'authored.md': '# Authored\n\nBlog post about work.',
+  });
+
+  const result = await loadLifeContext('life-work');
+
+  expect(result).toContain('--- LIFE CONTEXT INDEX ---');
+  expect(result).toContain('# Work Summary'); // summary.md content inlined
+  expect(result).toContain('Project updates.');
+  expect(result).toContain('authored.md'); // index entry
+  expect(result).toContain('timeline.md');
+  expect(result).toContain('work overview'); // description from frontmatter
+  // Full bodies of timeline.md / authored.md are NOT inlined
+  expect(result).not.toContain('- 2026-03-15 Meeting');
+  expect(result).not.toContain('Blog post about work.');
+  expect(result).toContain('--- END LIFE CONTEXT INDEX ---');
+});
+```
+
+- [ ] **Step 2.2: Update the remaining legacy-shape tests that will now fail**
+
+These four existing tests assert on the old concatenation behavior:
+
+1. `strips frontmatter from vault files` — keep as-is; `summary.md` body still gets its frontmatter stripped.
+2. `loads only the files that exist in the directory` — change assertion to check `summary.md` inlined + no other files in index (since none exist).
+3. `reads sensitive topics from _sensitive/ subdirectory` — change assertion from `'Abstract overview.'` (body) to `'summary.md'` (index entry) + sensitive-topic index still produced.
+4. `reads all .md files dynamically, not just hardcoded names` — change to assert all three filenames appear in the index.
+5. `loads _identity/writing-style.md and appends to context` — in the new world, writing-style is NOT in the topic index; we'll include its body in the index block header (same as before, sized permitting) since it's small. Keep test but adjust to assert `writing-style.md` content is inlined.
+6. `works without _identity/writing-style.md` — still valid.
+7. `sorts vault files alphabetically` — assert the index listing order, not body order.
+8. `applies size budget when reading from vault` — size budget no longer applies (index is always tiny). Replace with a new test: `index is bounded regardless of file count` — create 50 files, assert the index block is under 10 KB.
+
+- [ ] **Step 2.3: Rewrite loadFromVault to emit the index block**
+
+Replace the body of `loadFromVault` in `life-context-loader.ts`:
+
+```typescript
+async function loadFromVault(vaultPath: string, topic: Topic): Promise<string | null> {
+  const index = await buildVaultIndex(vaultPath, topic);
+  if (!index) return null;
+
+  const lines: string[] = ['--- LIFE CONTEXT INDEX ---', ''];
+
+  if (index.summary) {
+    lines.push('## summary.md', index.summary, '');
+  }
+
+  lines.push('## Available files in this topic');
+  lines.push('Use the Read tool to fetch any of these when relevant to the question:');
+  lines.push('');
+  for (const file of index.files) {
+    if (file.name === 'summary.md') continue; // already inlined above
+    const desc = file.description ? ` — ${file.description}` : '';
+    const sizeKb = (file.sizeBytes / 1024).toFixed(1);
+    lines.push(`- ${file.name} (${sizeKb} KB)${desc}`);
+  }
+  lines.push('');
+
+  // Append writing-style.md body if available (small, identity-critical)
+  try {
+    const ws = await readFile(join(vaultPath, '_identity', 'writing-style.md'), 'utf-8');
+    lines.push('## writing-style.md', stripFrontmatter(ws), '');
+  } catch {
+    // skip
+  }
+
+  lines.push('--- END LIFE CONTEXT INDEX ---');
+  return lines.join('\n');
+}
+```
+
+Update `loadLifeContext`'s signature to drop the `sizeBudget` parameter (no longer used):
+
+```typescript
+export async function loadLifeContext(agentName: string): Promise<string | null> {
+  const topic = AGENT_TOPIC_MAP[agentName];
+  if (!topic) return null;
+
+  const vaultPath = process.env.VAULT_PATH;
+  if (vaultPath) {
+    try {
+      return await loadFromVault(vaultPath, topic);
+    } catch (err) {
+      console.error(`[life-context-loader] Error loading vault context for ${agentName}:`, err);
+      return null;
+    }
+  }
+  return loadFromDrive(agentName, topic);
+}
+```
+
+Delete the exported `DEFAULT_TOPIC_SIZE_BUDGET` constant and any imports/tests that reference it.
+
+- [ ] **Step 2.4: Rewrite loadFromDrive to emit the same index shape**
+
+Replace the body of `loadFromDrive` with a directory listing that emits the same index format. It does not read file contents except for `summary.md`:
+
+```typescript
+async function loadFromDrive(agentName: string, topic: Topic): Promise<string | null> {
+  const client = getOrCreateClient();
+  if (!client) return null;
+
+  try {
+    const folderId = await resolveTopicFolderId(client, topic);
+    if (!folderId) {
+      console.error(`[life-context-loader] No folder found for topic "${topic}" in Drive`);
+      return null;
+    }
+
+    const listing = await client.driveList(folderId);
+    const mdFiles = listing.files.filter((f) => f.name.endsWith('.md'));
+    if (mdFiles.length === 0) return null;
+
+    const lines: string[] = ['--- LIFE CONTEXT INDEX ---', ''];
+
+    const summaryFile = mdFiles.find((f) => f.name === 'summary.md');
+    if (summaryFile) {
+      const result = await client.driveRead(summaryFile.file_id);
+      lines.push('## summary.md', stripFrontmatter(result.content), '');
+    }
+
+    lines.push('## Available files in this topic');
+    lines.push('Use the Read tool to fetch any of these when relevant to the question:');
+    lines.push('');
+    for (const f of mdFiles.sort((a, b) => a.name.localeCompare(b.name))) {
+      if (f.name === 'summary.md') continue;
+      const sizeKb = f.size_bytes != null ? `${(f.size_bytes / 1024).toFixed(1)} KB` : 'unknown size';
+      lines.push(`- ${f.name} (${sizeKb})`);
+    }
+    lines.push('');
+    lines.push('--- END LIFE CONTEXT INDEX ---');
+    return lines.join('\n');
+  } catch (err) {
+    console.error(`[life-context-loader] Error loading context for ${agentName}:`, err);
+    return null;
+  }
+}
+```
+
+- [ ] **Step 2.5: Update Drive-path tests in the same file**
+
+The Drive tests assert on old concatenated output (e.g. `expect(result).toContain('Project updates.');`). Rewrite each to assert on the new index format — `expect(result).toContain('## summary.md')` + `expect(result).toContain('Project updates.')` for summary; other files appear by name only in the `- filename.md` listing.
+
+Specifically update / delete:
+- `loads a single .md file` — keep, but only for summary.md case.
+- `loads multiple .md files sorted by modified date (newest first)` — sorting changes to alphabetical; rewrite assertion accordingly.
+- `backward compatible: existing 3-file folders produce same sections` — drop test (no longer meaningful).
+- `reads all .md files, not just hardcoded names` — assert on index listing, not body content.
+- `truncates oldest files when over size budget` — delete (size budget removed).
+- `truncates multiple files with correct count` — delete.
+- `always includes at least the first file even if over budget` — delete.
+- `works for different agent names` — keep with trivial adjustment.
+
+- [ ] **Step 2.6: Run the full test file, fix anything broken**
+
+```bash
+npx vitest run tests/ayumi/life-context-loader.test.ts
+```
+
+Iterate until green.
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add -A
+git commit -m "feat(ayumi): loadLifeContext returns index block, not concatenated content"
+```
+
+---
+
+### Task 3: Scoped tool-args helper
+
+The agent's system prompt gets the index; the CLI invocation needs `--allowed-tools` patterns scoped to the topic root so `Read`/`Grep`/`Glob` can only reach that topic.
+
+**Files:**
+- Modify: `src/ayumi/life-context-loader.ts`
+- Modify: `src/ayumi/index.ts`
+- Modify: `tests/ayumi/life-context-loader.test.ts`
+
+- [ ] **Step 3.1: Failing tests for getLifeContextToolArgs**
+
+```typescript
+describe('getLifeContextToolArgs', () => {
+  it('returns null for non-life-context agents', () => {
+    process.env.VAULT_PATH = tempDir;
+    expect(getLifeContextToolArgs('life-curator')).toBeNull();
+    expect(getLifeContextToolArgs('some-other-agent')).toBeNull();
+  });
+
+  it('returns null when VAULT_PATH is not set', () => {
+    delete process.env.VAULT_PATH;
+    expect(getLifeContextToolArgs('life-hobbies')).toBeNull();
+  });
+
+  it('emits --allowed-tools patterns scoped to the hobbies topic root', () => {
+    process.env.VAULT_PATH = '/data/vault';
+    const args = getLifeContextToolArgs('life-hobbies');
+    expect(args).toEqual([
+      '--allowed-tools',
+      'Read(/data/vault/topics/hobbies/**)',
+      'Grep(/data/vault/topics/hobbies/**)',
+      'Glob(/data/vault/topics/hobbies/**)',
+      'Read(/data/vault/_identity/writing-style.md)',
+    ]);
+  });
+
+  it('scopes sensitive topics to their _sensitive/ subdirectory', () => {
+    process.env.VAULT_PATH = '/data/vault';
+    const args = getLifeContextToolArgs('life-finance');
+    expect(args).toContain('Read(/data/vault/topics/_sensitive/finance/**)');
+    // Must NOT leak into the other sensitive topic
+    expect(args?.join(' ')).not.toContain('/_sensitive/health');
+    // Must NOT leak into tier-1/2 topics
+    expect(args?.join(' ')).not.toContain('/topics/work');
+  });
+
+  it('does not grant tools outside the topic tree', () => {
+    process.env.VAULT_PATH = '/data/vault';
+    const args = getLifeContextToolArgs('life-hobbies');
+    const joined = args!.join(' ');
+    expect(joined).not.toContain('/topics/work');
+    expect(joined).not.toContain('/_sensitive/');
+    // No unscoped Read/Grep
+    expect(args).not.toContain('Read');
+    expect(args).not.toContain('Grep');
+  });
+});
+```
+
+- [ ] **Step 3.2: Run the tests, confirm fail**
+
+```bash
+npx vitest run tests/ayumi/life-context-loader.test.ts -t getLifeContextToolArgs
+```
+
+- [ ] **Step 3.3: Implement getLifeContextToolArgs**
+
+Add at the end of `life-context-loader.ts`:
+
+```typescript
+export function getLifeContextToolArgs(agentName: string): string[] | null {
+  const topic = AGENT_TOPIC_MAP[agentName];
+  if (!topic) return null;
+  const vaultPath = process.env.VAULT_PATH;
+  if (!vaultPath) return null;
+
+  const topicRoot = topicVaultPath(vaultPath, topic);
+  const writingStyle = join(vaultPath, '_identity', 'writing-style.md');
+
+  return [
+    '--allowed-tools',
+    `Read(${topicRoot}/**)`,
+    `Grep(${topicRoot}/**)`,
+    `Glob(${topicRoot}/**)`,
+    `Read(${writingStyle})`,
+  ];
+}
+```
+
+- [ ] **Step 3.4: Export from src/ayumi/index.ts**
+
+```typescript
+import { loadLifeContext, getLifeContextToolArgs } from './life-context-loader.js';
+export { loadLifeContext, getLifeContextToolArgs };
+```
+
+- [ ] **Step 3.5: Run tests, confirm pass**
+
+```bash
+npx vitest run tests/ayumi/life-context-loader.test.ts
+```
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add -A
+git commit -m "feat(ayumi): add getLifeContextToolArgs for topic-scoped tool permissions"
+```
+
+---
+
+### Task 4: Wire into Discord and Slack adapters
+
+When `getLifeContextToolArgs` returns non-null for the active agent, the adapter must **replace** the default `toolArgs` with the scoped ones for that specific `sessionManager.send` call.
+
+**Files:**
+- Modify: `src/discord.ts`
+- Modify: `src/slack.ts`
+
+- [ ] **Step 4.1: Add the lazy import alongside getAgentContext in both adapters**
+
+In `discord.ts` (near line 15) and `slack.ts` (near line 15):
+
+```typescript
+let getLifeContextToolArgs: (agentName: string) => string[] | null = () => null;
+try {
+  const ayumi = await import('./ayumi/index.js');
+  getAgentContext = ayumi.getAgentContext;
+  getLifeContextToolArgs = ayumi.getLifeContextToolArgs;
+} catch {
+  // ayumi module absent — both no-ops
+}
+```
+
+Replace the existing single-function try block with this combined one.
+
+- [ ] **Step 4.2: Add a helper to compute effective tool args**
+
+Right above the four `sessionManager.send` call sites in each adapter file, compute:
+
+```typescript
+const lifeArgs = getLifeContextToolArgs(agentName);
+const effectiveToolArgs = lifeArgs ?? toolArgs;
+```
+
+Then pass `effectiveToolArgs` instead of `toolArgs` to `sessionManager.send`.
+
+There are four send call sites in `discord.ts` (around lines 483, 561, 596, 660) and the corresponding ones in `slack.ts`. Only the sites dispatching **to an agent by name** need the override — the fan-out and synthesis sites already know the `agentName` / `handoff.agentName`.
+
+For each site:
+- If `agentName` is available in scope (most sites), call `getLifeContextToolArgs(agentName)`.
+- For the fan-out synthesis call in `discord.ts:596`, the synthesis agent is `originAgentName` — use that.
+- For the fan-out individual call at `discord.ts:561`, use `handoff.agentName`.
+- For the handoff call at `discord.ts:660`, use `handoff.agentName`.
+
+- [ ] **Step 4.3: Type-check**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no new errors.
+
+- [ ] **Step 4.4: Run the full test suite to make sure nothing broke**
+
+```bash
+npm test -- --reporter=default 2>&1 | tail -30
+```
+
+Expected: the 23 pre-existing failures in `tests/activity-engine.test.ts` and `tests/tmux-runtime.test.ts` remain; everything else green, including all `tests/ayumi/*` files.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(mpg): wire life-context tool scoping into Discord and Slack adapters"
+```
+
+---
+
+### Task 5: End-to-end verification
+
+- [ ] **Step 5.1: Build**
+
+```bash
+npm run build
+```
+
+- [ ] **Step 5.2: Inspect the generated index for hobbies against a real vault**
+
+Run a tiny Node script that loads the real vault path and prints what the agent would see. This proves the index is small and `mountains.md` is listed:
+
+```bash
+VAULT_PATH=/home/yamakei/Documents/ayumi/vault node -e "
+const mod = await import('./dist/ayumi/index.js');
+const ctx = await mod.getAgentContext('life-hobbies');
+console.log('INDEX LENGTH:', ctx.length, 'bytes');
+console.log('---');
+console.log(ctx);
+"
+```
+
+Verify:
+- Output under ~15 KB
+- `mountains.md` appears in the listing with a size label
+- `summary.md` body is inlined
+- No body of `cycling.md` is inlined (that was the old bloat)
+
+- [ ] **Step 5.3: Inspect the tool args**
+
+```bash
+VAULT_PATH=/home/yamakei/Documents/ayumi/vault node -e "
+const mod = await import('./dist/ayumi/index.js');
+console.log(mod.getLifeContextToolArgs('life-hobbies'));
+console.log(mod.getLifeContextToolArgs('life-finance'));
+console.log(mod.getLifeContextToolArgs('life-curator'));
+"
+```
+
+Verify `life-curator` returns `null`, the other two return topic-scoped `--allowed-tools` arrays.
+
+- [ ] **Step 5.4: Traversal probe**
+
+Spawn `claude` with the scoped allow-list and ask it to read a file outside the topic. Confirm the CLI blocks the call. This validates permission-pattern semantics rather than guessing:
+
+```bash
+VAULT_PATH=/home/yamakei/Documents/ayumi/vault claude \
+  --print 'Use the Read tool to read /home/yamakei/Documents/ayumi/vault/topics/work/summary.md and print the first line.' \
+  --allowed-tools 'Read(/home/yamakei/Documents/ayumi/vault/topics/hobbies/**)' \
+  --output-format json 2>&1 | tail -20
+```
+
+Expected: the tool call is denied (or the agent reports it could not read the file). If permission patterns do NOT block this, this is a critical finding that requires going back to Option A (MCP); report to PM before proceeding.
+
+Also probe `..` traversal:
+
+```bash
+VAULT_PATH=/home/yamakei/Documents/ayumi/vault claude \
+  --print 'Use the Read tool to read /home/yamakei/Documents/ayumi/vault/topics/hobbies/../work/summary.md' \
+  --allowed-tools 'Read(/home/yamakei/Documents/ayumi/vault/topics/hobbies/**)' \
+  --output-format json 2>&1 | tail -20
+```
+
+- [ ] **Step 5.5: End-to-end mountaineering probe**
+
+```bash
+VAULT_PATH=/home/yamakei/Documents/ayumi/vault claude \
+  --print 'What mountains have I climbed? Use the Read tool on any vault file that would help.' \
+  --append-system-prompt "$(VAULT_PATH=/home/yamakei/Documents/ayumi/vault node -e "const m = await import('./dist/ayumi/index.js'); console.log(await m.getAgentContext('life-hobbies'));")" \
+  --allowed-tools 'Read(/home/yamakei/Documents/ayumi/vault/topics/hobbies/**)' 'Grep(/home/yamakei/Documents/ayumi/vault/topics/hobbies/**)' \
+  --output-format json 2>&1 | tail -30
+```
+
+Verify the response mentions content that could only have come from `mountains.md` (e.g. Hotaka, Tsurugi, specific years 2004-2019).
+
+---
+
+### Task 6: PR
+
+- [ ] **Step 6.1: Push branch**
+
+```bash
+git push -u origin mpg/1496034088690257952-engineer
+```
+
+- [ ] **Step 6.2: Open PR against master**
+
+```bash
+gh pr create --repo yama-kei/multi-project-gateway --base master \
+  --title "feat: on-demand life-context loading for topic agents" \
+  --body "<see below>"
+```
+
+Body:
+
+```
+## Summary
+- Replaces the 24 KB pre-loaded vault block with a lightweight index (`summary.md` + file listing with sizes/descriptions) so large files like `mountains.md` (107 KB) stay reachable instead of getting silently dropped.
+- Topic agents receive scoped `Read`/`Grep`/`Glob` permissions limited to their topic directory via `--allowed-tools` patterns.
+- Sensitive-topic isolation preserved (hobbies agent cannot read finance/health).
+
+Closes yama-kei/ayumi#64.
+
+## Test plan
+- [x] `tests/ayumi/life-context-loader.test.ts` updated and extended (scoping, traversal probe, sensitive-topic isolation)
+- [x] Full `npm test` run — only the 23 pre-existing unrelated failures remain in `activity-engine.test.ts` and `tmux-runtime.test.ts`
+- [x] Verified end-to-end: `@life-hobbies` answers a mountaineering question using `mountains.md` content (see issue thread for transcript)
+- [x] Traversal probe: confirmed Claude CLI permission matcher denies cross-topic and `..` reads
+```

--- a/docs/superpowers/plans/2026-04-20-on-demand-life-context.md
+++ b/docs/superpowers/plans/2026-04-20-on-demand-life-context.md
@@ -2,9 +2,11 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+> **2026-04-21 architecture correction.** Step 5.4 probes revealed that the CLI's `--allowed-tools 'Read(path/**)'` patterns do NOT restrict filesystem reads — they're an extension mechanism (cf. `Bash(git *)`), not a restrictor for tools like `Read`. The enforceable mechanism is **CWD-based scoping**: `Read`/`Grep`/`Glob` are scoped to the process CWD by default, and `--add-dir` extends that scope. Tasks 3 and 4 (originally written around `--allowed-tools` patterns) are superseded by **Tasks 3B and 4B** below. The `getLifeContextToolArgs` helper is replaced by `getLifeContextRunArgs`, which returns `{ cwd, extraArgs }` — the adapter spawns the CLI from the topic directory with `--add-dir <vault>/_identity`. Task 4B (`composeClaudeArgs`) is still needed to strip `--dangerously-skip-permissions` from gateway defaults when an enforcement flag is present, since the production config sets it by default.
+
 **Goal:** Replace the 24 KB pre-loaded vault block for topic agents (`@life-hobbies` etc.) with a lightweight index plus topic-scoped `Read`/`Grep`/`Glob` tools, so agents can fetch only the files they need and large files like `mountains.md` (107 KB) become reachable.
 
-**Architecture:** `loadLifeContext(agentName)` keeps its signature but now returns an **index** — `summary.md` content (if present) plus a file listing with per-file size + frontmatter description — instead of concatenated file bodies. A new `getLifeContextToolArgs(agentName)` returns scoped `--allowed-tools` patterns like `Read(<vault>/topics/<topic>/**)` that the Discord/Slack adapters merge into the CLI invocation. The agent uses the built-in `Read`/`Grep`/`Glob` tools; Claude CLI's permission matcher enforces the topic boundary.
+**Architecture (corrected):** `loadLifeContext(agentName)` returns an **index** — `summary.md` content (if present) plus a file listing with per-file size + frontmatter description — instead of concatenated file bodies. A new `getLifeContextRunArgs(agentName)` returns `{ cwd: <topic-dir>, extraArgs: ['--add-dir', <vault>/_identity] }`; the Discord/Slack adapters spawn `claude` from that CWD with those extras. The agent uses the built-in `Read`/`Grep`/`Glob` tools; Claude CLI's default CWD-scoping (plus `--add-dir` for writing-style.md) enforces the topic boundary.
 
 **Tech Stack:** TypeScript, Node.js `fs/promises`, Vitest. No new dependencies.
 
@@ -508,6 +510,188 @@ Expected: the 23 pre-existing failures in `tests/activity-engine.test.ts` and `t
 ```bash
 git add -A
 git commit -m "feat(mpg): wire life-context tool scoping into Discord and Slack adapters"
+```
+
+---
+
+### Task 4B: Make --allowed-tools actually enforce in production
+
+**Added 2026-04-21 after Task 5.4 probe surfaced the issue.**
+
+Gateway default `claudeArgs` contains `--dangerously-skip-permissions` (see `config.json`), which bypasses the CLI's permission matcher. The current `session-manager.ts:168` composition `[...defaults.claudeArgs, ...item.extraArgs]` puts both flags on the command line. Empirically, `--dangerously-skip-permissions` wins: the scoped `--allowed-tools` patterns are ignored and any file is readable. This defeats the sensitive-topic isolation acceptance criterion from yama-kei/ayumi#64.
+
+Fix: when the caller supplies `--allowed-tools` (or `--disallowed-tools`) via `extraArgs`, strip `--dangerously-skip-permissions` from the default args before composing. The two flags are contradictory — an explicit allowlist implies the caller wants enforcement, so honor that.
+
+**Files:**
+- Modify: `src/claude-cli.ts` — add `composeClaudeArgs` helper
+- Modify: `src/session-manager.ts` — use it at line 168
+- Modify: `tests/claude-cli.test.ts` — unit-test the helper
+
+- [ ] **Step 4B.1: Failing test for composeClaudeArgs in tests/claude-cli.test.ts**
+
+Add a new `describe` block:
+
+```typescript
+describe('composeClaudeArgs', () => {
+  it('returns defaults when extras is undefined', () => {
+    expect(composeClaudeArgs(['--output-format', 'json'], undefined))
+      .toEqual(['--output-format', 'json']);
+  });
+
+  it('returns defaults when extras is empty', () => {
+    expect(composeClaudeArgs(['--output-format', 'json'], []))
+      .toEqual(['--output-format', 'json']);
+  });
+
+  it('concatenates defaults + extras when extras has no permission flags', () => {
+    expect(composeClaudeArgs(['--output-format', 'json'], ['--model', 'opus']))
+      .toEqual(['--output-format', 'json', '--model', 'opus']);
+  });
+
+  it('strips --dangerously-skip-permissions when extras supplies --allowed-tools', () => {
+    const defaults = ['--dangerously-skip-permissions', '--output-format', 'json'];
+    const extras = ['--allowed-tools', 'Read(/vault/topics/hobbies/**)'];
+    expect(composeClaudeArgs(defaults, extras))
+      .toEqual(['--output-format', 'json', '--allowed-tools', 'Read(/vault/topics/hobbies/**)']);
+  });
+
+  it('strips --dangerously-skip-permissions when extras supplies --disallowed-tools', () => {
+    const defaults = ['--dangerously-skip-permissions', '--output-format', 'json'];
+    const extras = ['--disallowed-tools', 'Bash'];
+    expect(composeClaudeArgs(defaults, extras))
+      .toEqual(['--output-format', 'json', '--disallowed-tools', 'Bash']);
+  });
+
+  it('keeps --dangerously-skip-permissions when extras has no permission flags', () => {
+    const defaults = ['--dangerously-skip-permissions', '--output-format', 'json'];
+    const extras = ['--model', 'opus'];
+    expect(composeClaudeArgs(defaults, extras))
+      .toEqual(['--dangerously-skip-permissions', '--output-format', 'json', '--model', 'opus']);
+  });
+});
+```
+
+Run: `npx vitest run tests/claude-cli.test.ts -t composeClaudeArgs` — expect import/undefined failure.
+
+- [ ] **Step 4B.2: Implement composeClaudeArgs in src/claude-cli.ts**
+
+Add after `buildToolArgs`:
+
+```typescript
+/**
+ * Compose the final CLI base args: gateway defaults plus per-send extras.
+ *
+ * When extras contain --allowed-tools or --disallowed-tools, strip
+ * --dangerously-skip-permissions from defaults. The flags are contradictory:
+ * an explicit allow/deny list implies the caller wants permission
+ * enforcement; --dangerously-skip-permissions would bypass it.
+ */
+export function composeClaudeArgs(defaults: string[], extras: string[] | undefined): string[] {
+  if (!extras || extras.length === 0) return [...defaults];
+  const hasPermissionFlag = extras.includes('--allowed-tools') || extras.includes('--disallowed-tools');
+  const base = hasPermissionFlag
+    ? defaults.filter((a) => a !== '--dangerously-skip-permissions')
+    : defaults;
+  return [...base, ...extras];
+}
+```
+
+Run tests, confirm pass.
+
+- [ ] **Step 4B.3: Use composeClaudeArgs in session-manager.ts**
+
+Replace `src/session-manager.ts:168`:
+
+```typescript
+// old
+const effectiveArgs = item.extraArgs ? [...defaults.claudeArgs, ...item.extraArgs] : defaults.claudeArgs;
+// new
+const effectiveArgs = composeClaudeArgs(defaults.claudeArgs, item.extraArgs);
+```
+
+Add the import at the top.
+
+- [ ] **Step 4B.4: Type-check and run full suite**
+
+```bash
+npx tsc --noEmit && npm test -- --reporter=default 2>&1 | tail -30
+```
+
+- [ ] **Step 4B.5: Commit**
+
+```bash
+git add -A
+git commit -m "fix(mpg): strip --dangerously-skip-permissions when an allowlist is supplied"
+```
+
+---
+
+### Task 4C: Replace --allowed-tools scoping with CWD + --add-dir
+
+**Added 2026-04-21 after further probing showed `--allowed-tools 'Read(pattern)'` does not restrict filesystem reads.** The CLI treats `--allowed-tools` as an extension mechanism (e.g. `Bash(git *)`) and does not use it to *restrict* the default CWD-scoped `Read`/`Grep`/`Glob` permission. To actually scope a topic agent to its directory, we must **spawn the CLI with `cwd` set to the topic directory** and use `--add-dir <vault>/_identity` to grant access to `writing-style.md` outside that CWD.
+
+This supersedes the `--allowed-tools`-based scoping introduced in Tasks 3 and 4.
+
+**Files:**
+- Modify: `src/ayumi/life-context-loader.ts` — replace `getLifeContextToolArgs` with `getLifeContextRunArgs` (returns `{ cwd, extraArgs }`)
+- Modify: `src/ayumi/index.ts` — re-export `getLifeContextRunArgs` + `LifeContextRunArgs` type
+- Modify: `src/discord.ts`, `src/slack.ts` — `resolveExtraArgs` → `resolveLifeContextRun`; each of the 4 send call sites now takes `cwd` and `extraArgs` from the helper
+- Modify: `src/claude-cli.ts` (`composeClaudeArgs`) — add `--add-dir` to the list of flags that trigger stripping of `--dangerously-skip-permissions`
+- Modify: `tests/ayumi/life-context-loader.test.ts` — rewrite the scoping tests to assert on `{ cwd, extraArgs }`
+- Modify: `tests/claude-cli.test.ts` — add `--add-dir` case
+
+- [ ] **Step 4C.1: `getLifeContextRunArgs` shape**
+
+```typescript
+export interface LifeContextRunArgs {
+  cwd: string;          // topic directory, e.g. <vault>/topics/hobbies
+  extraArgs: string[];  // ['--add-dir', '<vault>/_identity']
+}
+export function getLifeContextRunArgs(agentName: string): LifeContextRunArgs | null;
+```
+
+Returns `null` for non-topic agents or when `VAULT_PATH` is unset.
+
+- [ ] **Step 4C.2: Adapter wiring** — both `discord.ts` and `slack.ts` get an identical helper:
+
+```typescript
+function resolveLifeContextRun(
+  agentName: string | undefined,
+  defaultCwd: string,
+  defaultExtraArgs: string[],
+): { cwd: string; extraArgs: string[] | undefined } {
+  if (agentName) {
+    const run = getLifeContextRunArgs(agentName);
+    if (run) return { cwd: run.cwd, extraArgs: run.extraArgs };
+  }
+  return {
+    cwd: defaultCwd,
+    extraArgs: defaultExtraArgs.length > 0 ? defaultExtraArgs : undefined,
+  };
+}
+```
+
+Each of the 4 `sessionManager.send` call sites in each file:
+
+```typescript
+const spawn = resolveLifeContextRun(agentName, resolved.directory, toolArgs);
+await sessionManager.send(key, spawn.cwd, msg, { ..., extraArgs: spawn.extraArgs });
+```
+
+- [ ] **Step 4C.3: Extend composeClaudeArgs** — add `--add-dir` to the set of flags that strip `--dangerously-skip-permissions` (update both the implementation and test).
+
+- [ ] **Step 4C.4: Empirical E2E probe (critical)**
+
+From a neutral CWD, spawn `claude` with the production-style defaults AND the scoped cwd/extraArgs. Confirm:
+1. In-scope Read succeeds (hobbies/summary.md)
+2. Cross-topic Read denied (work/summary.md → `permission_denials` non-empty)
+3. Writing-style read succeeds (via `--add-dir`)
+
+- [ ] **Step 4C.5: Commit**
+
+```bash
+git add -A
+git commit -m "fix(mpg): scope topic agents via CWD + --add-dir instead of --allowed-tools"
 ```
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@slack/bolt": "^4.6.0",
-        "ayumi": "github:yama-kei/ayumi#main",
         "discord.js": "^14.14.0",
         "dotenv": "^16.4.0"
       },
@@ -26,6 +25,9 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "optionalDependencies": {
+        "ayumi": "github:yama-kei/ayumi#main"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -1489,6 +1491,7 @@
     "node_modules/ayumi": {
       "version": "0.1.0",
       "resolved": "git+ssh://git@github.com/yama-kei/ayumi.git#34585e99fb893938f7dd71ad405e3eb342a06c0b",
+      "optional": true,
       "dependencies": {
         "robots-parser": "^3.0.1"
       },
@@ -2999,6 +3002,7 @@
       "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-3.0.1.tgz",
       "integrity": "sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10.0.0"
       }

--- a/scripts/inspect-life-context.ts
+++ b/scripts/inspect-life-context.ts
@@ -1,0 +1,13 @@
+import { getAgentContext, getLifeContextRunArgs } from '../src/ayumi/index.js';
+
+async function main(): Promise<void> {
+  const agent = process.argv[2] ?? 'life-hobbies';
+  const ctx = await getAgentContext(agent);
+  console.log(`=== AGENT: ${agent}`);
+  console.log(`=== INDEX LENGTH (bytes): ${ctx?.length ?? 'null'}`);
+  console.log('=== RUN ARGS:', JSON.stringify(getLifeContextRunArgs(agent), null, 2));
+  console.log('=== FULL INDEX ===');
+  console.log(ctx);
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/src/ayumi/index.ts
+++ b/src/ayumi/index.ts
@@ -9,9 +9,10 @@
  * `import { ... } from 'ayumi'` directly.
  */
 
-import { loadLifeContext, getLifeContextToolArgs } from './life-context-loader.js';
+import { loadLifeContext, getLifeContextRunArgs } from './life-context-loader.js';
 
-export { loadLifeContext, getLifeContextToolArgs };
+export { loadLifeContext, getLifeContextRunArgs };
+export type { LifeContextRunArgs } from './life-context-loader.js';
 
 // Re-export ayumi pipeline primitives that other MPG modules may need
 export type { Topic, DriveBroker, ExtractedContent, ClassificationResult, ArticleSummary, LLMComplete } from 'ayumi';

--- a/src/ayumi/index.ts
+++ b/src/ayumi/index.ts
@@ -9,9 +9,9 @@
  * `import { ... } from 'ayumi'` directly.
  */
 
-import { loadLifeContext } from './life-context-loader.js';
+import { loadLifeContext, getLifeContextToolArgs } from './life-context-loader.js';
 
-export { loadLifeContext };
+export { loadLifeContext, getLifeContextToolArgs };
 
 // Re-export ayumi pipeline primitives that other MPG modules may need
 export type { Topic, DriveBroker, ExtractedContent, ClassificationResult, ArticleSummary, LLMComplete } from 'ayumi';

--- a/src/ayumi/life-context-loader.ts
+++ b/src/ayumi/life-context-loader.ts
@@ -295,6 +295,34 @@ async function loadFromDrive(agentName: string, topic: Topic): Promise<string | 
   }
 }
 
+/**
+ * Build `--allowed-tools` patterns that scope Read/Grep/Glob to the agent's
+ * topic directory. Returns null for non-life-context agents or when
+ * VAULT_PATH is unset (there is nothing to scope to).
+ *
+ * Replaces any gateway-default allowed-tools list for the target agent so
+ * that, e.g., @life-hobbies cannot Read vault/topics/_sensitive/finance/ or
+ * any path outside vault/topics/hobbies/.
+ */
+export function getLifeContextToolArgs(agentName: string): string[] | null {
+  const topic = AGENT_TOPIC_MAP[agentName];
+  if (!topic) return null;
+
+  const vaultPath = process.env.VAULT_PATH;
+  if (!vaultPath) return null;
+
+  const topicRoot = topicVaultPath(vaultPath, topic);
+  const writingStyle = join(vaultPath, '_identity', 'writing-style.md');
+
+  return [
+    '--allowed-tools',
+    `Read(${topicRoot}/**)`,
+    `Grep(${topicRoot}/**)`,
+    `Glob(${topicRoot}/**)`,
+    `Read(${writingStyle})`,
+  ];
+}
+
 /** Reset module-level state (for testing). */
 export function _resetForTest(): void {
   brokerClient = null;

--- a/src/ayumi/life-context-loader.ts
+++ b/src/ayumi/life-context-loader.ts
@@ -15,8 +15,9 @@
  * The loader emits a compact *index* of the topic's vault: summary.md body
  * (if present), a file listing with sizes and frontmatter descriptions, and
  * the _identity/writing-style.md body. The agent fetches individual files
- * on demand via the Read/Grep/Glob tools, which the Discord/Slack adapters
- * scope to the topic root via getLifeContextToolArgs().
+ * on demand via the Read/Grep/Glob tools. The Discord/Slack adapters spawn
+ * the CLI from the topic directory (see getLifeContextRunArgs) so the
+ * default CWD-scoped permission model confines reads to that topic.
  */
 
 import { readFile, readdir } from 'node:fs/promises';
@@ -295,16 +296,30 @@ async function loadFromDrive(agentName: string, topic: Topic): Promise<string | 
   }
 }
 
+export interface LifeContextRunArgs {
+  /** CWD to spawn Claude from — the topic directory. */
+  cwd: string;
+  /** Extra CLI args, notably `--add-dir` to grant writing-style.md access. */
+  extraArgs: string[];
+}
+
 /**
- * Build `--allowed-tools` patterns that scope Read/Grep/Glob to the agent's
- * topic directory. Returns null for non-life-context agents or when
- * VAULT_PATH is unset (there is nothing to scope to).
+ * Build the CLI spawn parameters that scope a topic agent's filesystem
+ * access to its topic directory. Returns null for non-life-context agents
+ * or when VAULT_PATH is unset.
  *
- * Replaces any gateway-default allowed-tools list for the target agent so
- * that, e.g., @life-hobbies cannot Read vault/topics/_sensitive/finance/ or
- * any path outside vault/topics/hobbies/.
+ * The Claude CLI scopes Read/Grep/Glob to the process CWD by default (when
+ * permission checks are enforced). We spawn from the topic directory so
+ * the agent cannot read sibling topics — e.g. @life-hobbies cannot read
+ * vault/topics/_sensitive/finance/ or vault/topics/work/. We then add
+ * vault/_identity/ via --add-dir so the agent can read writing-style.md.
+ *
+ * Note: --allowed-tools path patterns were tried first but the CLI's
+ * permission matcher does not restrict CWD-scoped reads via --allowed-tools
+ * (it's an extension mechanism for tools like Bash(git *), not a restrictor
+ * for filesystem reads). CWD scoping is the enforceable mechanism.
  */
-export function getLifeContextToolArgs(agentName: string): string[] | null {
+export function getLifeContextRunArgs(agentName: string): LifeContextRunArgs | null {
   const topic = AGENT_TOPIC_MAP[agentName];
   if (!topic) return null;
 
@@ -312,15 +327,12 @@ export function getLifeContextToolArgs(agentName: string): string[] | null {
   if (!vaultPath) return null;
 
   const topicRoot = topicVaultPath(vaultPath, topic);
-  const writingStyle = join(vaultPath, '_identity', 'writing-style.md');
+  const identityDir = join(vaultPath, '_identity');
 
-  return [
-    '--allowed-tools',
-    `Read(${topicRoot}/**)`,
-    `Grep(${topicRoot}/**)`,
-    `Glob(${topicRoot}/**)`,
-    `Read(${writingStyle})`,
-  ];
+  return {
+    cwd: topicRoot,
+    extraArgs: ['--add-dir', identityDir],
+  };
 }
 
 /** Reset module-level state (for testing). */

--- a/src/ayumi/life-context-loader.ts
+++ b/src/ayumi/life-context-loader.ts
@@ -58,6 +58,68 @@ function topicVaultPath(vaultPath: string, topic: Topic): string {
   return join(vaultPath, 'topics', topic);
 }
 
+export interface VaultIndexFile {
+  name: string;
+  sizeBytes: number;
+  description: string | null;
+}
+
+export interface VaultIndex {
+  summary: string | null;
+  files: VaultIndexFile[];
+}
+
+function parseFrontmatterDescription(content: string): string | null {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+  const descLine = match[1].split('\n').find((l) => /^description:\s*/.test(l));
+  if (!descLine) return null;
+  const value = descLine.replace(/^description:\s*/, '').trim().replace(/^["']|["']$/g, '');
+  return value || null;
+}
+
+function stripFrontmatter(content: string): string {
+  return content.replace(/^---[\s\S]*?---\n*/, '');
+}
+
+/**
+ * Build a lightweight index of a topic's vault directory: summary.md body
+ * (if present) plus per-file name/size/description for all .md files.
+ * Returns null if the directory does not exist or has no .md files.
+ */
+export async function buildVaultIndex(vaultPath: string, topic: Topic): Promise<VaultIndex | null> {
+  const dir = topicVaultPath(vaultPath, topic);
+  let names: string[];
+  try {
+    const entries = await readdir(dir);
+    names = entries.filter((f) => f.endsWith('.md')).sort();
+  } catch {
+    return null;
+  }
+  if (names.length === 0) return null;
+
+  const files: VaultIndexFile[] = [];
+  let summary: string | null = null;
+
+  for (const name of names) {
+    try {
+      const content = await readFile(join(dir, name), 'utf-8');
+      files.push({
+        name,
+        sizeBytes: Buffer.byteLength(content, 'utf-8'),
+        description: parseFrontmatterDescription(content),
+      });
+      if (name === 'summary.md') {
+        summary = stripFrontmatter(content);
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return { summary, files };
+}
+
 /**
  * Load life-context from the local vault filesystem.
  * Reads all .md files from the topic directory (sorted alphabetically).

--- a/src/ayumi/life-context-loader.ts
+++ b/src/ayumi/life-context-loader.ts
@@ -12,9 +12,11 @@
  *   life-finance → vault/topics/_sensitive/finance/
  *   life-health  → vault/topics/_sensitive/health/
  *
- * Files read: all .md files in the topic directory (sorted alphabetically).
- * Also loads _identity/writing-style.md for every topic agent.
- * Missing files/directories are skipped gracefully — a new or empty vault still works.
+ * The loader emits a compact *index* of the topic's vault: summary.md body
+ * (if present), a file listing with sizes and frontmatter descriptions, and
+ * the _identity/writing-style.md body. The agent fetches individual files
+ * on demand via the Read/Grep/Glob tools, which the Discord/Slack adapters
+ * scope to the topic root via getLifeContextToolArgs().
  */
 
 import { readFile, readdir } from 'node:fs/promises';
@@ -32,9 +34,6 @@ const AGENT_TOPIC_MAP: Record<string, Topic> = {
 };
 
 const SENSITIVE_TOPICS: Topic[] = ['finance', 'health'];
-
-/** Maximum bytes of context content per topic before truncation. */
-export const DEFAULT_TOPIC_SIZE_BUDGET = 24 * 1024; // 24 KB
 
 /** Re-resolve folder IDs after this many milliseconds (5 minutes). */
 const FOLDER_CACHE_TTL_MS = 5 * 60 * 1000;
@@ -121,76 +120,53 @@ export async function buildVaultIndex(vaultPath: string, topic: Topic): Promise<
 }
 
 /**
- * Load life-context from the local vault filesystem.
- * Reads all .md files from the topic directory (sorted alphabetically).
- * Also appends _identity/writing-style.md if it exists.
- * Missing directories are handled gracefully.
+ * Format a VaultIndex and optional writing-style body into an agent-facing
+ * block. Kept separate so vault and Drive loaders share a single format.
  */
-async function loadFromVault(
-  vaultPath: string,
-  topic: Topic,
-  sizeBudget: number,
-): Promise<string | null> {
-  const dir = topicVaultPath(vaultPath, topic);
+function formatIndexBlock(index: VaultIndex, writingStyleBody: string | null): string {
+  const lines: string[] = ['--- LIFE CONTEXT INDEX ---', ''];
 
-  // Dynamically discover all .md files in the topic directory
-  let mdFileNames: string[];
+  if (index.summary) {
+    lines.push('## summary.md', index.summary, '');
+  }
+
+  lines.push('## Available files in this topic');
+  lines.push('Use the Read tool to fetch any of these when relevant to the question.');
+  lines.push('Use the Grep tool to search across them.');
+  lines.push('');
+  for (const file of index.files) {
+    if (file.name === 'summary.md') continue;
+    const sizeKb = (file.sizeBytes / 1024).toFixed(1);
+    const desc = file.description ? ` — ${file.description}` : '';
+    lines.push(`- ${file.name} (${sizeKb} KB)${desc}`);
+  }
+  lines.push('');
+
+  if (writingStyleBody) {
+    lines.push('## writing-style.md', writingStyleBody, '');
+  }
+
+  lines.push('--- END LIFE CONTEXT INDEX ---');
+  return lines.join('\n');
+}
+
+/**
+ * Emit the index block for a local-filesystem vault. Returns null when the
+ * topic directory is missing or empty.
+ */
+async function loadFromVault(vaultPath: string, topic: Topic): Promise<string | null> {
+  const index = await buildVaultIndex(vaultPath, topic);
+  if (!index) return null;
+
+  let writingStyleBody: string | null = null;
   try {
-    const entries = await readdir(dir);
-    mdFileNames = entries.filter((f) => f.endsWith('.md')).sort();
+    const content = await readFile(join(vaultPath, '_identity', 'writing-style.md'), 'utf-8');
+    writingStyleBody = stripFrontmatter(content);
   } catch {
-    // Directory doesn't exist — skip gracefully
-    return null;
+    // writing-style.md missing — continue without it
   }
 
-  if (mdFileNames.length === 0) return null;
-
-  const sections: string[] = [];
-  let totalSize = 0;
-  let filesIncluded = 0;
-
-  for (const fileName of mdFileNames) {
-    try {
-      const content = await readFile(join(dir, fileName), 'utf-8');
-      // Strip frontmatter for context injection (agents don't need YAML metadata)
-      const stripped = content.replace(/^---[\s\S]*?---\n*/, '');
-      const section = `## ${fileName}\n${stripped}`;
-      const sectionSize = new TextEncoder().encode(section).length;
-
-      if (totalSize + sectionSize > sizeBudget && sections.length > 0) {
-        const remaining = mdFileNames.length - filesIncluded;
-        if (remaining > 0) {
-          sections.push(`[truncated: ${remaining} file${remaining > 1 ? 's' : ''} omitted due to size budget]`);
-        }
-        break;
-      }
-
-      sections.push(section);
-      totalSize += sectionSize;
-      filesIncluded++;
-    } catch {
-      continue;
-    }
-  }
-
-  // Append _identity/writing-style.md if it exists
-  try {
-    const writingStylePath = join(vaultPath, '_identity', 'writing-style.md');
-    const content = await readFile(writingStylePath, 'utf-8');
-    const stripped = content.replace(/^---[\s\S]*?---\n*/, '');
-    const section = `## writing-style.md\n${stripped}`;
-    const sectionSize = new TextEncoder().encode(section).length;
-
-    if (totalSize + sectionSize <= sizeBudget || sections.length === 0) {
-      sections.push(section);
-    }
-  } catch {
-    // writing-style.md doesn't exist — skip gracefully
-  }
-
-  if (sections.length === 0) return null;
-
-  return `--- LIFE CONTEXT DATA ---\n\n${sections.join('\n\n')}\n\n--- END LIFE CONTEXT DATA ---`;
+  return formatIndexBlock(index, writingStyleBody);
 }
 
 /**
@@ -200,29 +176,24 @@ async function loadFromVault(
  * Otherwise, falls back to Drive via broker (legacy path).
  *
  * @param agentName Agent preset name (e.g., 'life-work', 'life-travel')
- * @param sizeBudget Maximum bytes of content per topic (default: DEFAULT_TOPIC_SIZE_BUDGET)
- * @returns Formatted context string, or null if not a life-context agent or loading fails
+ * @returns Index block to inject into the agent's system prompt, or null
+ *          if not a life-context agent or loading fails.
  */
-export async function loadLifeContext(
-  agentName: string,
-  sizeBudget: number = DEFAULT_TOPIC_SIZE_BUDGET,
-): Promise<string | null> {
+export async function loadLifeContext(agentName: string): Promise<string | null> {
   const topic = AGENT_TOPIC_MAP[agentName];
   if (!topic) return null;
 
-  // Primary path: local vault
   const vaultPath = process.env.VAULT_PATH;
   if (vaultPath) {
     try {
-      return await loadFromVault(vaultPath, topic, sizeBudget);
+      return await loadFromVault(vaultPath, topic);
     } catch (err) {
       console.error(`[life-context-loader] Error loading vault context for ${agentName}:`, err);
       return null;
     }
   }
 
-  // Fallback: Drive via broker
-  return loadFromDrive(agentName, topic, sizeBudget);
+  return loadFromDrive(agentName, topic);
 }
 
 // ---- Drive fallback (legacy path) ----
@@ -282,11 +253,7 @@ async function resolveTopicFolderId(client: BrokerClient, topic: string): Promis
   return topicFolderIds[topic] ?? null;
 }
 
-async function loadFromDrive(
-  agentName: string,
-  topic: Topic,
-  sizeBudget: number,
-): Promise<string | null> {
+async function loadFromDrive(agentName: string, topic: Topic): Promise<string | null> {
   const client = getOrCreateClient();
   if (!client) return null;
 
@@ -298,41 +265,30 @@ async function loadFromDrive(
     }
 
     const listing = await client.driveList(folderId);
-
     const mdFiles = listing.files
       .filter((f) => f.name.endsWith('.md'))
-      .sort((a, b) => (b.modified_at ?? '').localeCompare(a.modified_at ?? ''));
+      .sort((a, b) => a.name.localeCompare(b.name));
 
     if (mdFiles.length === 0) {
       console.warn(`[life-context-loader] No .md files in ${topic} folder`);
       return null;
     }
 
-    const sections: string[] = [];
-    let totalSize = 0;
-    let filesIncluded = 0;
-
-    for (const file of mdFiles) {
-      const result = await client.driveRead(file.file_id);
-      const section = `## ${file.name}\n${result.content}`;
-      const sectionSize = new TextEncoder().encode(section).length;
-
-      if (totalSize + sectionSize > sizeBudget && sections.length > 0) {
-        const omitted = mdFiles.length - filesIncluded;
-        if (omitted > 0) {
-          sections.push(`[truncated: ${omitted} file${omitted > 1 ? 's' : ''} omitted due to size budget]`);
-        }
-        break;
-      }
-
-      sections.push(section);
-      totalSize += sectionSize;
-      filesIncluded++;
+    // Inline summary.md body; the rest are listed by name/size only.
+    const summaryFile = mdFiles.find((f) => f.name === 'summary.md');
+    let summary: string | null = null;
+    if (summaryFile) {
+      const result = await client.driveRead(summaryFile.file_id);
+      summary = stripFrontmatter(result.content);
     }
 
-    if (sections.length === 0) return null;
+    const files: VaultIndexFile[] = mdFiles.map((f) => ({
+      name: f.name,
+      sizeBytes: f.size_bytes ?? 0,
+      description: null,
+    }));
 
-    return `--- LIFE CONTEXT DATA ---\n\n${sections.join('\n\n')}\n\n--- END LIFE CONTEXT DATA ---`;
+    return formatIndexBlock({ summary, files }, null);
   } catch (err) {
     console.error(`[life-context-loader] Error loading context for ${agentName}:`, err);
     return null;

--- a/src/claude-cli.ts
+++ b/src/claude-cli.ts
@@ -84,6 +84,25 @@ export function buildToolArgs(
   return args;
 }
 
+const PERMISSION_FLAGS = ['--allowed-tools', '--disallowed-tools', '--add-dir'] as const;
+
+/**
+ * Compose the final CLI base args: gateway defaults plus per-send extras.
+ *
+ * When extras contain any permission-aware flag (--allowed-tools,
+ * --disallowed-tools, --add-dir), strip --dangerously-skip-permissions from
+ * defaults. Those flags imply the caller wants permission enforcement, and
+ * --dangerously-skip-permissions would bypass the check entirely.
+ */
+export function composeClaudeArgs(defaults: string[], extras: string[] | undefined): string[] {
+  if (!extras || extras.length === 0) return [...defaults];
+  const hasPermissionFlag = PERMISSION_FLAGS.some((flag) => extras.includes(flag));
+  const base = hasPermissionFlag
+    ? defaults.filter((a) => a !== '--dangerously-skip-permissions')
+    : defaults;
+  return [...base, ...extras];
+}
+
 export function buildClaudeArgs(
   baseArgs: string[],
   prompt: string,

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -13,26 +13,35 @@ import { downloadAttachments, buildAttachmentPrompt, type AttachmentConfig, DEFA
 import type { AgentConfig } from './config.js';
 // Ayumi life-context module — optional, gracefully absent
 let getAgentContext: (agentName: string) => Promise<string | null> = async () => null;
-let getLifeContextToolArgs: (agentName: string) => string[] | null = () => null;
+interface LifeContextRunArgs { cwd: string; extraArgs: string[] }
+let getLifeContextRunArgs: (agentName: string) => LifeContextRunArgs | null = () => null;
 try {
   const ayumi = await import('./ayumi/index.js');
   getAgentContext = ayumi.getAgentContext;
-  getLifeContextToolArgs = ayumi.getLifeContextToolArgs;
+  getLifeContextRunArgs = ayumi.getLifeContextRunArgs;
 } catch {
   // Ayumi module not available — no life context injection
 }
 
 /**
- * Resolve the CLI extraArgs for a send: if the agent is a life-context
- * topic agent, its topic-scoped --allowed-tools patterns replace the
- * gateway-default tool list. Otherwise the gateway default is used.
+ * Resolve the CLI spawn parameters (cwd + extraArgs) for a send. For a
+ * life-context topic agent, the CWD is switched to the topic directory
+ * and --add-dir is added so the agent can still read _identity/. For all
+ * other agents, the project cwd and gateway-default tool args are used.
  */
-function resolveExtraArgs(agentName: string | undefined, defaultArgs: string[]): string[] | undefined {
+function resolveLifeContextRun(
+  agentName: string | undefined,
+  defaultCwd: string,
+  defaultExtraArgs: string[],
+): { cwd: string; extraArgs: string[] | undefined } {
   if (agentName) {
-    const scoped = getLifeContextToolArgs(agentName);
-    if (scoped) return scoped;
+    const run = getLifeContextRunArgs(agentName);
+    if (run) return { cwd: run.cwd, extraArgs: run.extraArgs };
   }
-  return defaultArgs.length > 0 ? defaultArgs : undefined;
+  return {
+    cwd: defaultCwd,
+    extraArgs: defaultExtraArgs.length > 0 ? defaultExtraArgs : undefined,
+  };
 }
 
 // Ayumi curator commands — optional, gracefully absent
@@ -495,15 +504,16 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
         return;
       }
 
+      const primarySpawn = resolveLifeContextRun(activeAgent?.agentName, resolved.directory, toolArgs);
       const result = await sessionManager.send(
         sessionKey,
-        resolved.directory,
+        primarySpawn.cwd,
         userPrompt,
         {
           worktree: replyChannel.isThread() ? true : undefined,
           systemPrompt,
           timeoutMs: activeAgent ? resolveAgentTimeout(activeAgent.agent, config.defaults) : config.defaults.agentTimeoutMs,
-          extraArgs: resolveExtraArgs(activeAgent?.agentName, toolArgs),
+          extraArgs: primarySpawn.extraArgs,
           guildId: message.guildId ?? undefined,
         },
       );
@@ -571,11 +581,12 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
               const key = `${threadId}:${handoff.agentName}`;
               const sysPrompt = await buildSystemPrompt(handoff.agentName, handoff.agent);
               const fanOutTimeout = Math.min(resolveAgentTimeout(handoff.agent, config.defaults), 5 * 60 * 1000);
+              const spawn = resolveLifeContextRun(handoff.agentName, resolved.directory, toolArgs);
               return {
                 agentName: handoff.agentName,
                 result: await sessionManager.send(
-                  key, resolved.directory, responseText,
-                  { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: sysPrompt, timeoutMs: fanOutTimeout, extraArgs: resolveExtraArgs(handoff.agentName, toolArgs) },
+                  key, spawn.cwd, responseText,
+                  { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: sysPrompt, timeoutMs: fanOutTimeout, extraArgs: spawn.extraArgs },
                 ),
               };
             });
@@ -608,9 +619,10 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
 
             let synthesisResult;
             try {
+              const synthSpawn = resolveLifeContextRun(currentAgentName ?? undefined, resolved.directory, toolArgs);
               synthesisResult = await sessionManager.send(
-                originKey, resolved.directory, synthesisPrompt,
-                { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: originSysPrompt, timeoutMs: originAgent ? resolveAgentTimeout(originAgent, config.defaults) : config.defaults.agentTimeoutMs, extraArgs: resolveExtraArgs(currentAgentName ?? undefined, toolArgs) },
+                originKey, synthSpawn.cwd, synthesisPrompt,
+                { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: originSysPrompt, timeoutMs: originAgent ? resolveAgentTimeout(originAgent, config.defaults) : config.defaults.agentTimeoutMs, extraArgs: synthSpawn.extraArgs },
               );
             } catch (synthErr) {
               const msg = synthErr instanceof Error ? synthErr.message : String(synthErr);
@@ -672,11 +684,12 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
 
           let handoffResult;
           try {
+            const handoffSpawn = resolveLifeContextRun(handoff.agentName, resolved.directory, toolArgs);
             handoffResult = await sessionManager.send(
               handoffKey,
-              resolved.directory,
+              handoffSpawn.cwd,
               responseText,
-              { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: handoffPrompt, timeoutMs: resolveAgentTimeout(handoff.agent, config.defaults), extraArgs: resolveExtraArgs(handoff.agentName, toolArgs) },
+              { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: handoffPrompt, timeoutMs: resolveAgentTimeout(handoff.agent, config.defaults), extraArgs: handoffSpawn.extraArgs },
             );
           } catch (handoffErr) {
             const msg = handoffErr instanceof Error ? handoffErr.message : String(handoffErr);

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -13,11 +13,26 @@ import { downloadAttachments, buildAttachmentPrompt, type AttachmentConfig, DEFA
 import type { AgentConfig } from './config.js';
 // Ayumi life-context module — optional, gracefully absent
 let getAgentContext: (agentName: string) => Promise<string | null> = async () => null;
+let getLifeContextToolArgs: (agentName: string) => string[] | null = () => null;
 try {
   const ayumi = await import('./ayumi/index.js');
   getAgentContext = ayumi.getAgentContext;
+  getLifeContextToolArgs = ayumi.getLifeContextToolArgs;
 } catch {
   // Ayumi module not available — no life context injection
+}
+
+/**
+ * Resolve the CLI extraArgs for a send: if the agent is a life-context
+ * topic agent, its topic-scoped --allowed-tools patterns replace the
+ * gateway-default tool list. Otherwise the gateway default is used.
+ */
+function resolveExtraArgs(agentName: string | undefined, defaultArgs: string[]): string[] | undefined {
+  if (agentName) {
+    const scoped = getLifeContextToolArgs(agentName);
+    if (scoped) return scoped;
+  }
+  return defaultArgs.length > 0 ? defaultArgs : undefined;
 }
 
 // Ayumi curator commands — optional, gracefully absent
@@ -488,7 +503,7 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
           worktree: replyChannel.isThread() ? true : undefined,
           systemPrompt,
           timeoutMs: activeAgent ? resolveAgentTimeout(activeAgent.agent, config.defaults) : config.defaults.agentTimeoutMs,
-          extraArgs: toolArgs.length > 0 ? toolArgs : undefined,
+          extraArgs: resolveExtraArgs(activeAgent?.agentName, toolArgs),
           guildId: message.guildId ?? undefined,
         },
       );
@@ -560,7 +575,7 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
                 agentName: handoff.agentName,
                 result: await sessionManager.send(
                   key, resolved.directory, responseText,
-                  { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: sysPrompt, timeoutMs: fanOutTimeout, extraArgs: toolArgs.length > 0 ? toolArgs : undefined },
+                  { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: sysPrompt, timeoutMs: fanOutTimeout, extraArgs: resolveExtraArgs(handoff.agentName, toolArgs) },
                 ),
               };
             });
@@ -595,7 +610,7 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
             try {
               synthesisResult = await sessionManager.send(
                 originKey, resolved.directory, synthesisPrompt,
-                { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: originSysPrompt, timeoutMs: originAgent ? resolveAgentTimeout(originAgent, config.defaults) : config.defaults.agentTimeoutMs, extraArgs: toolArgs.length > 0 ? toolArgs : undefined },
+                { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: originSysPrompt, timeoutMs: originAgent ? resolveAgentTimeout(originAgent, config.defaults) : config.defaults.agentTimeoutMs, extraArgs: resolveExtraArgs(currentAgentName ?? undefined, toolArgs) },
               );
             } catch (synthErr) {
               const msg = synthErr instanceof Error ? synthErr.message : String(synthErr);
@@ -661,7 +676,7 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
               handoffKey,
               resolved.directory,
               responseText,
-              { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: handoffPrompt, timeoutMs: resolveAgentTimeout(handoff.agent, config.defaults), extraArgs: toolArgs.length > 0 ? toolArgs : undefined },
+              { worktree: replyChannel.isThread() ? true : undefined, systemPrompt: handoffPrompt, timeoutMs: resolveAgentTimeout(handoff.agent, config.defaults), extraArgs: resolveExtraArgs(handoff.agentName, toolArgs) },
             );
           } catch (handoffErr) {
             const msg = handoffErr instanceof Error ? handoffErr.message : String(handoffErr);

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import type { ClaudeResult } from './claude-cli.js';
+import { composeClaudeArgs, type ClaudeResult } from './claude-cli.js';
 import type { AgentRuntime } from './agent-runtime.js';
 import type { SessionStore, PersistedSession } from './session-store.js';
 import type { PulseEmitter } from './pulse-events.js';
@@ -165,7 +165,7 @@ export function createSessionManager(defaults: {
 
     while (session.queue.length > 0) {
       const item = session.queue.shift()!;
-      const effectiveArgs = item.extraArgs ? [...defaults.claudeArgs, ...item.extraArgs] : defaults.claudeArgs;
+      const effectiveArgs = composeClaudeArgs(defaults.claudeArgs, item.extraArgs);
       await acquireSlot();
       if (pulseEmitter) {
         // Session keys are "threadId:agentName" for agent sessions, "threadId" for default

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -13,11 +13,26 @@ import { handleCommand } from './discord.js';
 
 // Ayumi life-context module — optional, gracefully absent
 let getAgentContext: (agentName: string) => Promise<string | null> = async () => null;
+let getLifeContextToolArgs: (agentName: string) => string[] | null = () => null;
 try {
   const ayumi = await import('./ayumi/index.js');
   getAgentContext = ayumi.getAgentContext;
+  getLifeContextToolArgs = ayumi.getLifeContextToolArgs;
 } catch {
   // Ayumi module not available — no life context injection
+}
+
+/**
+ * Resolve the CLI extraArgs for a send: if the agent is a life-context
+ * topic agent, its topic-scoped --allowed-tools patterns replace the
+ * gateway-default tool list. Otherwise the gateway default is used.
+ */
+function resolveExtraArgs(agentName: string | undefined, defaultArgs: string[]): string[] | undefined {
+  if (agentName) {
+    const scoped = getLifeContextToolArgs(agentName);
+    if (scoped) return scoped;
+  }
+  return defaultArgs.length > 0 ? defaultArgs : undefined;
 }
 
 /** Slack message text limit (~4000 chars, with margin). */
@@ -316,7 +331,7 @@ export function createSlackBot(
           worktree: isThread ? true : undefined,
           systemPrompt,
           timeoutMs: activeAgent ? resolveAgentTimeout(activeAgent.agent, config.defaults) : config.defaults.agentTimeoutMs,
-          extraArgs: toolArgs.length > 0 ? toolArgs : undefined,
+          extraArgs: resolveExtraArgs(activeAgent?.agentName, toolArgs),
         },
       );
 
@@ -396,7 +411,7 @@ export function createSlackBot(
                 agentName: handoff.agentName,
                 result: await sessionManager.send(
                   key, resolved.directory, responseText,
-                  { worktree: true, systemPrompt: sysPrompt, timeoutMs: fanOutTimeout, extraArgs: toolArgs.length > 0 ? toolArgs : undefined },
+                  { worktree: true, systemPrompt: sysPrompt, timeoutMs: fanOutTimeout, extraArgs: resolveExtraArgs(handoff.agentName, toolArgs) },
                 ),
               };
             });
@@ -428,7 +443,7 @@ export function createSlackBot(
             try {
               synthesisResult = await sessionManager.send(
                 originKey, resolved.directory, synthesisPrompt,
-                { worktree: true, systemPrompt: originSysPrompt, timeoutMs: originAgent ? resolveAgentTimeout(originAgent, config.defaults) : config.defaults.agentTimeoutMs, extraArgs: toolArgs.length > 0 ? toolArgs : undefined },
+                { worktree: true, systemPrompt: originSysPrompt, timeoutMs: originAgent ? resolveAgentTimeout(originAgent, config.defaults) : config.defaults.agentTimeoutMs, extraArgs: resolveExtraArgs(currentAgentName ?? undefined, toolArgs) },
               );
             } catch (synthErr) {
               const errMsg = synthErr instanceof Error ? synthErr.message : String(synthErr);
@@ -493,7 +508,7 @@ export function createSlackBot(
               handoffKey,
               resolved.directory,
               responseText,
-              { worktree: true, systemPrompt: handoffPrompt, timeoutMs: resolveAgentTimeout(handoff.agent, config.defaults), extraArgs: toolArgs.length > 0 ? toolArgs : undefined },
+              { worktree: true, systemPrompt: handoffPrompt, timeoutMs: resolveAgentTimeout(handoff.agent, config.defaults), extraArgs: resolveExtraArgs(handoff.agentName, toolArgs) },
             );
           } catch (handoffErr) {
             const errMsg = handoffErr instanceof Error ? handoffErr.message : String(handoffErr);

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -13,26 +13,35 @@ import { handleCommand } from './discord.js';
 
 // Ayumi life-context module — optional, gracefully absent
 let getAgentContext: (agentName: string) => Promise<string | null> = async () => null;
-let getLifeContextToolArgs: (agentName: string) => string[] | null = () => null;
+interface LifeContextRunArgs { cwd: string; extraArgs: string[] }
+let getLifeContextRunArgs: (agentName: string) => LifeContextRunArgs | null = () => null;
 try {
   const ayumi = await import('./ayumi/index.js');
   getAgentContext = ayumi.getAgentContext;
-  getLifeContextToolArgs = ayumi.getLifeContextToolArgs;
+  getLifeContextRunArgs = ayumi.getLifeContextRunArgs;
 } catch {
   // Ayumi module not available — no life context injection
 }
 
 /**
- * Resolve the CLI extraArgs for a send: if the agent is a life-context
- * topic agent, its topic-scoped --allowed-tools patterns replace the
- * gateway-default tool list. Otherwise the gateway default is used.
+ * Resolve the CLI spawn parameters (cwd + extraArgs) for a send. For a
+ * life-context topic agent, the CWD is switched to the topic directory
+ * and --add-dir is added so the agent can still read _identity/. For all
+ * other agents, the project cwd and gateway-default tool args are used.
  */
-function resolveExtraArgs(agentName: string | undefined, defaultArgs: string[]): string[] | undefined {
+function resolveLifeContextRun(
+  agentName: string | undefined,
+  defaultCwd: string,
+  defaultExtraArgs: string[],
+): { cwd: string; extraArgs: string[] | undefined } {
   if (agentName) {
-    const scoped = getLifeContextToolArgs(agentName);
-    if (scoped) return scoped;
+    const run = getLifeContextRunArgs(agentName);
+    if (run) return { cwd: run.cwd, extraArgs: run.extraArgs };
   }
-  return defaultArgs.length > 0 ? defaultArgs : undefined;
+  return {
+    cwd: defaultCwd,
+    extraArgs: defaultExtraArgs.length > 0 ? defaultExtraArgs : undefined,
+  };
 }
 
 /** Slack message text limit (~4000 chars, with margin). */
@@ -323,15 +332,16 @@ export function createSlackBot(
         return;
       }
 
+      const primarySpawn = resolveLifeContextRun(activeAgent?.agentName, resolved.directory, toolArgs);
       const result = await sessionManager.send(
         sessionKey,
-        resolved.directory,
+        primarySpawn.cwd,
         userPrompt,
         {
           worktree: isThread ? true : undefined,
           systemPrompt,
           timeoutMs: activeAgent ? resolveAgentTimeout(activeAgent.agent, config.defaults) : config.defaults.agentTimeoutMs,
-          extraArgs: resolveExtraArgs(activeAgent?.agentName, toolArgs),
+          extraArgs: primarySpawn.extraArgs,
         },
       );
 
@@ -407,11 +417,12 @@ export function createSlackBot(
               const key = `${replyThreadTs}:${handoff.agentName}`;
               const sysPrompt = await buildSystemPrompt(handoff.agentName, handoff.agent);
               const fanOutTimeout = Math.min(resolveAgentTimeout(handoff.agent, config.defaults), 5 * 60 * 1000);
+              const spawn = resolveLifeContextRun(handoff.agentName, resolved.directory, toolArgs);
               return {
                 agentName: handoff.agentName,
                 result: await sessionManager.send(
-                  key, resolved.directory, responseText,
-                  { worktree: true, systemPrompt: sysPrompt, timeoutMs: fanOutTimeout, extraArgs: resolveExtraArgs(handoff.agentName, toolArgs) },
+                  key, spawn.cwd, responseText,
+                  { worktree: true, systemPrompt: sysPrompt, timeoutMs: fanOutTimeout, extraArgs: spawn.extraArgs },
                 ),
               };
             });
@@ -441,9 +452,10 @@ export function createSlackBot(
 
             let synthesisResult;
             try {
+              const synthSpawn = resolveLifeContextRun(currentAgentName ?? undefined, resolved.directory, toolArgs);
               synthesisResult = await sessionManager.send(
-                originKey, resolved.directory, synthesisPrompt,
-                { worktree: true, systemPrompt: originSysPrompt, timeoutMs: originAgent ? resolveAgentTimeout(originAgent, config.defaults) : config.defaults.agentTimeoutMs, extraArgs: resolveExtraArgs(currentAgentName ?? undefined, toolArgs) },
+                originKey, synthSpawn.cwd, synthesisPrompt,
+                { worktree: true, systemPrompt: originSysPrompt, timeoutMs: originAgent ? resolveAgentTimeout(originAgent, config.defaults) : config.defaults.agentTimeoutMs, extraArgs: synthSpawn.extraArgs },
               );
             } catch (synthErr) {
               const errMsg = synthErr instanceof Error ? synthErr.message : String(synthErr);
@@ -504,11 +516,12 @@ export function createSlackBot(
 
           let handoffResult;
           try {
+            const handoffSpawn = resolveLifeContextRun(handoff.agentName, resolved.directory, toolArgs);
             handoffResult = await sessionManager.send(
               handoffKey,
-              resolved.directory,
+              handoffSpawn.cwd,
               responseText,
-              { worktree: true, systemPrompt: handoffPrompt, timeoutMs: resolveAgentTimeout(handoff.agent, config.defaults), extraArgs: resolveExtraArgs(handoff.agentName, toolArgs) },
+              { worktree: true, systemPrompt: handoffPrompt, timeoutMs: resolveAgentTimeout(handoff.agent, config.defaults), extraArgs: handoffSpawn.extraArgs },
             );
           } catch (handoffErr) {
             const errMsg = handoffErr instanceof Error ? handoffErr.message : String(handoffErr);

--- a/tests/ayumi/life-context-loader.test.ts
+++ b/tests/ayumi/life-context-loader.test.ts
@@ -401,3 +401,87 @@ describe('buildVaultIndex — local filesystem', () => {
     expect(index!.files.map((f) => f.name)).toContain('summary.md');
   });
 });
+
+// ---- getLifeContextToolArgs tests ----
+
+describe('getLifeContextToolArgs', () => {
+  it('returns null for non-life-context agents', () => {
+    process.env.VAULT_PATH = '/data/vault';
+    expect(getLifeContextToolArgs('life-curator')).toBeNull();
+    expect(getLifeContextToolArgs('pm')).toBeNull();
+    expect(getLifeContextToolArgs('unknown')).toBeNull();
+  });
+
+  it('returns null when VAULT_PATH is not set', () => {
+    delete process.env.VAULT_PATH;
+    expect(getLifeContextToolArgs('life-hobbies')).toBeNull();
+  });
+
+  it('emits --allowed-tools scoped to the hobbies topic root', () => {
+    process.env.VAULT_PATH = '/data/vault';
+    const args = getLifeContextToolArgs('life-hobbies');
+    expect(args).toEqual([
+      '--allowed-tools',
+      'Read(/data/vault/topics/hobbies/**)',
+      'Grep(/data/vault/topics/hobbies/**)',
+      'Glob(/data/vault/topics/hobbies/**)',
+      'Read(/data/vault/_identity/writing-style.md)',
+    ]);
+  });
+
+  it('scopes sensitive topics to topics/_sensitive/<topic>/', () => {
+    process.env.VAULT_PATH = '/data/vault';
+    const args = getLifeContextToolArgs('life-finance');
+    expect(args).toContain('Read(/data/vault/topics/_sensitive/finance/**)');
+    expect(args).toContain('Grep(/data/vault/topics/_sensitive/finance/**)');
+  });
+
+  it('isolates sensitive topics from each other and from tier-1/2 topics', () => {
+    process.env.VAULT_PATH = '/data/vault';
+    const finance = getLifeContextToolArgs('life-finance')!.join(' ');
+    // Finance agent must not reach health
+    expect(finance).not.toContain('/_sensitive/health');
+    // Finance agent must not reach non-sensitive topics
+    expect(finance).not.toContain('/topics/work');
+    expect(finance).not.toContain('/topics/hobbies');
+    expect(finance).not.toContain('/topics/travel');
+    expect(finance).not.toContain('/topics/social');
+  });
+
+  it('isolates non-sensitive topics from sensitive topics and siblings', () => {
+    process.env.VAULT_PATH = '/data/vault';
+    const hobbies = getLifeContextToolArgs('life-hobbies')!.join(' ');
+    expect(hobbies).not.toContain('/_sensitive/');
+    expect(hobbies).not.toContain('/topics/work');
+    expect(hobbies).not.toContain('/topics/travel');
+    expect(hobbies).not.toContain('/topics/social');
+  });
+
+  it('does not grant unscoped Read or Grep', () => {
+    process.env.VAULT_PATH = '/data/vault';
+    const args = getLifeContextToolArgs('life-hobbies')!;
+    // Each pattern-bearing tool entry must include the path scope
+    for (const entry of args) {
+      if (entry === '--allowed-tools') continue;
+      if (/^(Read|Grep|Glob)$/.test(entry)) {
+        throw new Error(`unscoped tool granted: ${entry}`);
+      }
+    }
+  });
+
+  it('emits patterns for all six life-* topic agents', () => {
+    process.env.VAULT_PATH = '/data/vault';
+    for (const [agent, expectedPath] of [
+      ['life-work', '/data/vault/topics/work/'],
+      ['life-travel', '/data/vault/topics/travel/'],
+      ['life-social', '/data/vault/topics/social/'],
+      ['life-hobbies', '/data/vault/topics/hobbies/'],
+      ['life-finance', '/data/vault/topics/_sensitive/finance/'],
+      ['life-health', '/data/vault/topics/_sensitive/health/'],
+    ] as const) {
+      const args = getLifeContextToolArgs(agent);
+      expect(args, `agent ${agent}`).not.toBeNull();
+      expect(args!.join(' '), `agent ${agent}`).toContain(`Read(${expectedPath}**)`);
+    }
+  });
+});

--- a/tests/ayumi/life-context-loader.test.ts
+++ b/tests/ayumi/life-context-loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { loadLifeContext, _resetForTest, buildVaultIndex, getLifeContextToolArgs } from '../../src/ayumi/life-context-loader.js';
+import { loadLifeContext, _resetForTest, buildVaultIndex, getLifeContextRunArgs } from '../../src/ayumi/life-context-loader.js';
 import type { BrokerClient, DriveFile, DriveListResult, DriveReadResult, DriveSearchResult } from '../../src/broker-client.js';
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -402,86 +402,68 @@ describe('buildVaultIndex — local filesystem', () => {
   });
 });
 
-// ---- getLifeContextToolArgs tests ----
+// ---- getLifeContextRunArgs tests ----
 
-describe('getLifeContextToolArgs', () => {
+describe('getLifeContextRunArgs', () => {
   it('returns null for non-life-context agents', () => {
     process.env.VAULT_PATH = '/data/vault';
-    expect(getLifeContextToolArgs('life-curator')).toBeNull();
-    expect(getLifeContextToolArgs('pm')).toBeNull();
-    expect(getLifeContextToolArgs('unknown')).toBeNull();
+    expect(getLifeContextRunArgs('life-curator')).toBeNull();
+    expect(getLifeContextRunArgs('pm')).toBeNull();
+    expect(getLifeContextRunArgs('unknown')).toBeNull();
   });
 
   it('returns null when VAULT_PATH is not set', () => {
     delete process.env.VAULT_PATH;
-    expect(getLifeContextToolArgs('life-hobbies')).toBeNull();
+    expect(getLifeContextRunArgs('life-hobbies')).toBeNull();
   });
 
-  it('emits --allowed-tools scoped to the hobbies topic root', () => {
+  it('returns topic-directory cwd + --add-dir for _identity for life-hobbies', () => {
     process.env.VAULT_PATH = '/data/vault';
-    const args = getLifeContextToolArgs('life-hobbies');
-    expect(args).toEqual([
-      '--allowed-tools',
-      'Read(/data/vault/topics/hobbies/**)',
-      'Grep(/data/vault/topics/hobbies/**)',
-      'Glob(/data/vault/topics/hobbies/**)',
-      'Read(/data/vault/_identity/writing-style.md)',
-    ]);
+    expect(getLifeContextRunArgs('life-hobbies')).toEqual({
+      cwd: '/data/vault/topics/hobbies',
+      extraArgs: ['--add-dir', '/data/vault/_identity'],
+    });
   });
 
-  it('scopes sensitive topics to topics/_sensitive/<topic>/', () => {
+  it('routes sensitive topics through topics/_sensitive/<topic>', () => {
     process.env.VAULT_PATH = '/data/vault';
-    const args = getLifeContextToolArgs('life-finance');
-    expect(args).toContain('Read(/data/vault/topics/_sensitive/finance/**)');
-    expect(args).toContain('Grep(/data/vault/topics/_sensitive/finance/**)');
+    expect(getLifeContextRunArgs('life-finance')).toEqual({
+      cwd: '/data/vault/topics/_sensitive/finance',
+      extraArgs: ['--add-dir', '/data/vault/_identity'],
+    });
   });
 
-  it('isolates sensitive topics from each other and from tier-1/2 topics', () => {
+  it('isolates each sensitive topic from its sibling', () => {
     process.env.VAULT_PATH = '/data/vault';
-    const finance = getLifeContextToolArgs('life-finance')!.join(' ');
-    // Finance agent must not reach health
-    expect(finance).not.toContain('/_sensitive/health');
-    // Finance agent must not reach non-sensitive topics
-    expect(finance).not.toContain('/topics/work');
-    expect(finance).not.toContain('/topics/hobbies');
-    expect(finance).not.toContain('/topics/travel');
-    expect(finance).not.toContain('/topics/social');
+    const finance = getLifeContextRunArgs('life-finance')!;
+    const health = getLifeContextRunArgs('life-health')!;
+    expect(finance.cwd).not.toContain('/health');
+    expect(health.cwd).not.toContain('/finance');
   });
 
-  it('isolates non-sensitive topics from sensitive topics and siblings', () => {
+  it('does not let non-sensitive topics reach sensitive dirs via cwd', () => {
     process.env.VAULT_PATH = '/data/vault';
-    const hobbies = getLifeContextToolArgs('life-hobbies')!.join(' ');
-    expect(hobbies).not.toContain('/_sensitive/');
-    expect(hobbies).not.toContain('/topics/work');
-    expect(hobbies).not.toContain('/topics/travel');
-    expect(hobbies).not.toContain('/topics/social');
+    const hobbies = getLifeContextRunArgs('life-hobbies')!;
+    expect(hobbies.cwd).not.toContain('/_sensitive/');
+    expect(hobbies.cwd).not.toContain('/topics/work');
+    // --add-dir grants only _identity, never another topic
+    expect(hobbies.extraArgs.join(' ')).not.toContain('/_sensitive/');
+    expect(hobbies.extraArgs.join(' ')).not.toContain('/topics/');
   });
 
-  it('does not grant unscoped Read or Grep', () => {
+  it('emits correct cwd for all six life-* topic agents', () => {
     process.env.VAULT_PATH = '/data/vault';
-    const args = getLifeContextToolArgs('life-hobbies')!;
-    // Each pattern-bearing tool entry must include the path scope
-    for (const entry of args) {
-      if (entry === '--allowed-tools') continue;
-      if (/^(Read|Grep|Glob)$/.test(entry)) {
-        throw new Error(`unscoped tool granted: ${entry}`);
-      }
-    }
-  });
-
-  it('emits patterns for all six life-* topic agents', () => {
-    process.env.VAULT_PATH = '/data/vault';
-    for (const [agent, expectedPath] of [
-      ['life-work', '/data/vault/topics/work/'],
-      ['life-travel', '/data/vault/topics/travel/'],
-      ['life-social', '/data/vault/topics/social/'],
-      ['life-hobbies', '/data/vault/topics/hobbies/'],
-      ['life-finance', '/data/vault/topics/_sensitive/finance/'],
-      ['life-health', '/data/vault/topics/_sensitive/health/'],
+    for (const [agent, expectedCwd] of [
+      ['life-work', '/data/vault/topics/work'],
+      ['life-travel', '/data/vault/topics/travel'],
+      ['life-social', '/data/vault/topics/social'],
+      ['life-hobbies', '/data/vault/topics/hobbies'],
+      ['life-finance', '/data/vault/topics/_sensitive/finance'],
+      ['life-health', '/data/vault/topics/_sensitive/health'],
     ] as const) {
-      const args = getLifeContextToolArgs(agent);
-      expect(args, `agent ${agent}`).not.toBeNull();
-      expect(args!.join(' '), `agent ${agent}`).toContain(`Read(${expectedPath}**)`);
+      const run = getLifeContextRunArgs(agent);
+      expect(run, `agent ${agent}`).not.toBeNull();
+      expect(run!.cwd, `agent ${agent}`).toBe(expectedCwd);
     }
   });
 });

--- a/tests/ayumi/life-context-loader.test.ts
+++ b/tests/ayumi/life-context-loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { loadLifeContext, _resetForTest, DEFAULT_TOPIC_SIZE_BUDGET } from '../../src/ayumi/life-context-loader.js';
+import { loadLifeContext, _resetForTest, buildVaultIndex, getLifeContextToolArgs } from '../../src/ayumi/life-context-loader.js';
 import type { BrokerClient, DriveFile, DriveListResult, DriveReadResult, DriveSearchResult } from '../../src/broker-client.js';
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -459,5 +459,42 @@ describe('loadLifeContext — Drive fallback', () => {
 
     const result = await loadLifeContext('life-travel');
     expect(result).toContain('Trip plans.');
+  });
+});
+
+// ---- buildVaultIndex tests ----
+
+describe('buildVaultIndex — local filesystem', () => {
+  it('lists .md files in a topic directory with size and description', async () => {
+    await setupVaultTopic('hobbies', {
+      'summary.md': '---\ndescription: hobbies overview\n---\n# Hobbies\n\nOverview.',
+      'mountains.md': '---\ndescription: mountaineering log 2004-2019\n---\n# Mountains\n\nBody.',
+      'cycling.md': '# Cycling\n\nNo frontmatter.',
+    });
+
+    const index = await buildVaultIndex(tempDir, 'hobbies');
+
+    expect(index).not.toBeNull();
+    expect(index!.summary).toContain('# Hobbies');
+    expect(index!.files.map((f) => f.name).sort()).toEqual(['cycling.md', 'mountains.md', 'summary.md']);
+
+    const mountains = index!.files.find((f) => f.name === 'mountains.md')!;
+    expect(mountains.description).toBe('mountaineering log 2004-2019');
+    expect(mountains.sizeBytes).toBeGreaterThan(0);
+
+    const cycling = index!.files.find((f) => f.name === 'cycling.md')!;
+    expect(cycling.description).toBeNull();
+  });
+
+  it('returns null when the topic directory does not exist', async () => {
+    const index = await buildVaultIndex(tempDir, 'hobbies');
+    expect(index).toBeNull();
+  });
+
+  it('resolves sensitive topics to topics/_sensitive/', async () => {
+    await setupVaultTopic('finance', { 'summary.md': '# Finance\n\nAbstract.' }, true);
+    const index = await buildVaultIndex(tempDir, 'finance');
+    expect(index).not.toBeNull();
+    expect(index!.files.map((f) => f.name)).toContain('summary.md');
   });
 });

--- a/tests/ayumi/life-context-loader.test.ts
+++ b/tests/ayumi/life-context-loader.test.ts
@@ -109,27 +109,29 @@ describe('loadLifeContext — vault path', () => {
     expect(result).toBeNull();
   });
 
-  it('loads all .md files from local vault when VAULT_PATH is set', async () => {
+  it('emits an index block with summary body and file listing', async () => {
     process.env.VAULT_PATH = tempDir;
     await setupVaultTopic('work', {
-      'summary.md': '---\ntier: 2\n---\n# Work Summary\n\nProject updates.',
+      'summary.md': '---\ntier: 2\ndescription: work overview\n---\n# Work Summary\n\nProject updates.',
       'timeline.md': '---\ntier: 2\n---\n# Timeline\n\n- 2026-03-15 Meeting',
       'authored.md': '# Authored\n\nBlog post about work.',
     });
 
     const result = await loadLifeContext('life-work');
 
-    expect(result).toContain('--- LIFE CONTEXT DATA ---');
-    expect(result).toContain('## summary.md');
+    expect(result).toContain('--- LIFE CONTEXT INDEX ---');
+    expect(result).toContain('--- END LIFE CONTEXT INDEX ---');
+    // summary.md body is inlined
+    expect(result).toContain('# Work Summary');
     expect(result).toContain('Project updates.');
-    expect(result).toContain('## timeline.md');
-    expect(result).toContain('Meeting');
-    expect(result).toContain('## authored.md');
-    expect(result).toContain('Blog post about work.');
-    expect(result).toContain('--- END LIFE CONTEXT DATA ---');
+    // Other files appear in the listing (by name + size), NOT their bodies
+    expect(result).toMatch(/- timeline\.md \(/);
+    expect(result).toMatch(/- authored\.md \(/);
+    expect(result).not.toContain('- 2026-03-15 Meeting');
+    expect(result).not.toContain('Blog post about work.');
   });
 
-  it('strips frontmatter from vault files', async () => {
+  it('strips frontmatter from the inlined summary body', async () => {
     process.env.VAULT_PATH = tempDir;
     await setupVaultTopic('work', {
       'summary.md': '---\ntier: 2\ntopic: work\ntype: summary\n---\n# Work Summary\n\nContent.',
@@ -142,7 +144,7 @@ describe('loadLifeContext — vault path', () => {
     expect(result).toContain('Content.');
   });
 
-  it('loads only the files that exist in the directory', async () => {
+  it('inlines summary body when only summary.md exists', async () => {
     process.env.VAULT_PATH = tempDir;
     await setupVaultTopic('work', {
       'summary.md': '# Work\n\nJust a summary.',
@@ -150,14 +152,12 @@ describe('loadLifeContext — vault path', () => {
 
     const result = await loadLifeContext('life-work');
 
-    expect(result).toContain('Just a summary.');
-    // Only summary.md exists in the directory
     expect(result).toContain('## summary.md');
+    expect(result).toContain('Just a summary.');
   });
 
   it('returns null when topic directory does not exist', async () => {
     process.env.VAULT_PATH = tempDir;
-    // No files created
     const result = await loadLifeContext('life-work');
     expect(result).toBeNull();
   });
@@ -170,10 +170,11 @@ describe('loadLifeContext — vault path', () => {
 
     const result = await loadLifeContext('life-finance');
 
+    expect(result).toContain('## summary.md');
     expect(result).toContain('Abstract overview.');
   });
 
-  it('reads all .md files dynamically, not just hardcoded names', async () => {
+  it('lists all .md files dynamically in the index, not just hardcoded names', async () => {
     process.env.VAULT_PATH = tempDir;
     await setupVaultTopic('work', {
       'summary.md': '# Summary\nOverview.',
@@ -183,26 +184,28 @@ describe('loadLifeContext — vault path', () => {
 
     const result = await loadLifeContext('life-work');
 
-    expect(result).toContain('## summary.md');
-    expect(result).toContain('## authored.md');
-    expect(result).toContain('## weekly-report.md');
+    // summary body inlined
+    expect(result).toContain('# Summary');
+    // other files appear by name in the listing
+    expect(result).toMatch(/- authored\.md /);
+    expect(result).toMatch(/- weekly-report\.md /);
   });
 
-  it('loads _identity/writing-style.md and appends to context', async () => {
+  it('inlines _identity/writing-style.md body when present', async () => {
     process.env.VAULT_PATH = tempDir;
     await setupVaultTopic('work', {
       'summary.md': '# Summary\nWork overview.',
     });
-    // Create _identity/writing-style.md
     await mkdir(join(tempDir, '_identity'), { recursive: true });
-    await writeFile(join(tempDir, '_identity', 'writing-style.md'), '---\ntype: identity\n---\n# Writing Style\n\nCasual, concise.');
+    await writeFile(
+      join(tempDir, '_identity', 'writing-style.md'),
+      '---\ntype: identity\n---\n# Writing Style\n\nCasual, concise.',
+    );
 
     const result = await loadLifeContext('life-work');
 
-    expect(result).toContain('## summary.md');
     expect(result).toContain('## writing-style.md');
     expect(result).toContain('Casual, concise.');
-    // Frontmatter should be stripped
     expect(result).not.toContain('type: identity');
   });
 
@@ -211,48 +214,48 @@ describe('loadLifeContext — vault path', () => {
     await setupVaultTopic('work', {
       'summary.md': '# Summary\nWork overview.',
     });
-    // No _identity directory created
 
     const result = await loadLifeContext('life-work');
 
-    expect(result).toContain('## summary.md');
+    expect(result).toContain('# Summary');
     expect(result).not.toContain('writing-style');
   });
 
-  it('sorts vault files alphabetically', async () => {
+  it('lists files alphabetically in the index', async () => {
     process.env.VAULT_PATH = tempDir;
     await setupVaultTopic('hobbies', {
       'cycling.md': '# Cycling\nRoad biking.',
       'authored.md': '# Authored\nBlog posts.',
-      'summary.md': '# Summary\nOverview.',
+      'mountains.md': '# Mountains\nMountaineering.',
     });
 
     const result = await loadLifeContext('life-hobbies');
 
-    // Alphabetical: authored.md, cycling.md, summary.md
-    const authoredIdx = result!.indexOf('## authored.md');
-    const cyclingIdx = result!.indexOf('## cycling.md');
-    const summaryIdx = result!.indexOf('## summary.md');
+    // Alphabetical in the listing: authored.md, cycling.md, mountains.md
+    const authoredIdx = result!.indexOf('- authored.md');
+    const cyclingIdx = result!.indexOf('- cycling.md');
+    const mountainsIdx = result!.indexOf('- mountains.md');
+    expect(authoredIdx).toBeGreaterThan(-1);
     expect(authoredIdx).toBeLessThan(cyclingIdx);
-    expect(cyclingIdx).toBeLessThan(summaryIdx);
+    expect(cyclingIdx).toBeLessThan(mountainsIdx);
   });
 
-  it('applies size budget when reading from vault', async () => {
+  it('index block stays small regardless of topic file count', async () => {
     process.env.VAULT_PATH = tempDir;
-    const largeContent = 'x'.repeat(200);
-    await setupVaultTopic('work', {
-      'a-summary.md': `# Summary\n${largeContent}`,
-      'b-timeline.md': `# Timeline\n${largeContent}`,
-      'c-entities.md': `# Entities\n${largeContent}`,
-    });
+    const bigBody = 'x'.repeat(20_000);
+    const files: Record<string, string> = { 'summary.md': '# Hobbies\nShort summary.' };
+    for (let i = 0; i < 50; i++) {
+      files[`file-${String(i).padStart(3, '0')}.md`] = `# File ${i}\n${bigBody}`;
+    }
+    await setupVaultTopic('hobbies', files);
 
-    // Budget fits ~2 files (alphabetical order: a-summary, b-timeline, c-entities)
-    const result = await loadLifeContext('life-work', 500);
+    const result = await loadLifeContext('life-hobbies');
 
-    expect(result).toContain('## a-summary.md');
-    expect(result).toContain('## b-timeline.md');
-    expect(result).not.toContain('## c-entities.md');
-    expect(result).toContain('[truncated');
+    expect(result).not.toBeNull();
+    // Bodies of non-summary files must NOT be inlined
+    expect(result).not.toContain(bigBody);
+    // Block should stay small — index only, no file bodies
+    expect(result!.length).toBeLessThan(10 * 1024);
   });
 });
 
@@ -285,7 +288,7 @@ describe('loadLifeContext — Drive fallback', () => {
     expect(result).toBeNull();
   });
 
-  it('loads a single .md file', async () => {
+  it('inlines summary.md body and emits the index block', async () => {
     setupDriveFolders([
       makeDriveFile('summary.md', '2026-03-15T00:00:00Z'),
     ]);
@@ -296,155 +299,55 @@ describe('loadLifeContext — Drive fallback', () => {
     } satisfies DriveReadResult);
 
     const result = await loadLifeContext('life-work');
-    expect(result).toContain('--- LIFE CONTEXT DATA ---');
+    expect(result).toContain('--- LIFE CONTEXT INDEX ---');
     expect(result).toContain('## summary.md');
     expect(result).toContain('Key project updates.');
-    expect(result).toContain('--- END LIFE CONTEXT DATA ---');
+    expect(result).toContain('--- END LIFE CONTEXT INDEX ---');
   });
 
-  it('loads multiple .md files sorted by modified date (newest first)', async () => {
+  it('lists non-summary files by name only (no body inlined)', async () => {
     setupDriveFolders([
-      makeDriveFile('entities.md', '2026-03-01T00:00:00Z'),
       makeDriveFile('summary.md', '2026-03-15T00:00:00Z'),
       makeDriveFile('timeline.md', '2026-03-10T00:00:00Z'),
+      makeDriveFile('entities.md', '2026-03-01T00:00:00Z'),
     ]);
     (mockClient.driveRead as ReturnType<typeof vi.fn>).mockImplementation((fileId: string) => {
-      const contentMap: Record<string, string> = {
-        'id-summary.md': '# Summary\nNewest content',
-        'id-timeline.md': '# Timeline\nMiddle content',
-        'id-entities.md': '# Entities\nOldest content',
-      };
       return Promise.resolve({
         name: fileId.replace('id-', ''),
         mime_type: 'text/plain',
-        content: contentMap[fileId] ?? '',
+        content: `# Heading\nBody for ${fileId}`,
       } satisfies DriveReadResult);
     });
 
     const result = await loadLifeContext('life-work');
-    expect(result).not.toBeNull();
-
-    // Verify ordering: summary (newest) before timeline before entities (oldest)
-    const summaryIdx = result!.indexOf('## summary.md');
-    const timelineIdx = result!.indexOf('## timeline.md');
-    const entitiesIdx = result!.indexOf('## entities.md');
-    expect(summaryIdx).toBeLessThan(timelineIdx);
-    expect(timelineIdx).toBeLessThan(entitiesIdx);
+    // summary.md body inlined
+    expect(result).toContain('Body for id-summary.md');
+    // Other files appear by name in the listing, NOT their bodies
+    expect(result).toMatch(/- timeline\.md /);
+    expect(result).toMatch(/- entities\.md /);
+    expect(result).not.toContain('Body for id-timeline.md');
+    expect(result).not.toContain('Body for id-entities.md');
+    // Drive loader only reads summary.md's content
+    expect(mockClient.driveRead).toHaveBeenCalledTimes(1);
   });
 
-  it('backward compatible: existing 3-file folders produce same sections', async () => {
-    setupDriveFolders([
-      makeDriveFile('summary.md', '2026-03-15T00:00:00Z'),
-      makeDriveFile('timeline.md', '2026-03-14T00:00:00Z'),
-      makeDriveFile('entities.md', '2026-03-13T00:00:00Z'),
-    ]);
-    (mockClient.driveRead as ReturnType<typeof vi.fn>).mockImplementation((fileId: string) => {
-      const contentMap: Record<string, string> = {
-        'id-summary.md': '# Work — Summary\n\nProject updates.',
-        'id-timeline.md': '# Work — Timeline\n\n- 2026-03-15 Meeting',
-        'id-entities.md': '# Work — Entities\n\n## People\n- Alice',
-      };
-      return Promise.resolve({
-        name: fileId.replace('id-', ''),
-        mime_type: 'text/plain',
-        content: contentMap[fileId] ?? '',
-      } satisfies DriveReadResult);
-    });
-
-    const result = await loadLifeContext('life-work');
-    expect(result).toContain('## summary.md');
-    expect(result).toContain('## timeline.md');
-    expect(result).toContain('## entities.md');
-    expect(result).toContain('Project updates.');
-    expect(result).toContain('Meeting');
-    expect(result).toContain('Alice');
-  });
-
-  it('reads all .md files, not just hardcoded names', async () => {
+  it('lists all .md files in the index, excludes non-.md files', async () => {
     setupDriveFolders([
       makeDriveFile('summary.md', '2026-03-15T00:00:00Z'),
       makeDriveFile('weekly-report.md', '2026-03-14T00:00:00Z'),
       makeDriveFile('notes.md', '2026-03-13T00:00:00Z'),
       { ...makeDriveFile('data.json', '2026-03-16T00:00:00Z'), name: 'data.json' },
     ]);
-    (mockClient.driveRead as ReturnType<typeof vi.fn>).mockImplementation((fileId: string) => {
-      return Promise.resolve({
-        name: fileId.replace('id-', ''),
-        mime_type: 'text/plain',
-        content: `Content of ${fileId}`,
-      } satisfies DriveReadResult);
-    });
-
-    const result = await loadLifeContext('life-work');
-    expect(result).toContain('## summary.md');
-    expect(result).toContain('## weekly-report.md');
-    expect(result).toContain('## notes.md');
-    // Should NOT include non-.md files
-    expect(result).not.toContain('data.json');
-  });
-
-  it('truncates oldest files when over size budget', async () => {
-    // Create files where each is ~100 bytes of content
-    const largeContent = 'x'.repeat(100);
-    setupDriveFolders([
-      makeDriveFile('newest.md', '2026-03-15T00:00:00Z'),
-      makeDriveFile('middle.md', '2026-03-10T00:00:00Z'),
-      makeDriveFile('oldest.md', '2026-03-05T00:00:00Z'),
-    ]);
-    (mockClient.driveRead as ReturnType<typeof vi.fn>).mockImplementation((fileId: string) => {
-      return Promise.resolve({
-        name: fileId.replace('id-', ''),
-        mime_type: 'text/plain',
-        content: largeContent,
-      } satisfies DriveReadResult);
-    });
-
-    // Set budget to fit ~2 files (each section is "## name\n" + content ≈ 115 bytes)
-    const result = await loadLifeContext('life-work', 250);
-    expect(result).toContain('## newest.md');
-    expect(result).toContain('## middle.md');
-    expect(result).not.toContain('## oldest.md');
-    expect(result).toContain('[truncated: 1 file omitted due to size budget]');
-  });
-
-  it('truncates multiple files with correct count', async () => {
-    const largeContent = 'x'.repeat(200);
-    setupDriveFolders([
-      makeDriveFile('file1.md', '2026-03-15T00:00:00Z'),
-      makeDriveFile('file2.md', '2026-03-10T00:00:00Z'),
-      makeDriveFile('file3.md', '2026-03-05T00:00:00Z'),
-      makeDriveFile('file4.md', '2026-03-01T00:00:00Z'),
-    ]);
-    (mockClient.driveRead as ReturnType<typeof vi.fn>).mockImplementation((fileId: string) => {
-      return Promise.resolve({
-        name: fileId.replace('id-', ''),
-        mime_type: 'text/plain',
-        content: largeContent,
-      } satisfies DriveReadResult);
-    });
-
-    // Budget fits only ~1 file
-    const result = await loadLifeContext('life-work', 250);
-    expect(result).toContain('## file1.md');
-    expect(result).not.toContain('## file2.md');
-    expect(result).toContain('[truncated: 3 files omitted due to size budget]');
-  });
-
-  it('always includes at least the first file even if over budget', async () => {
-    const largeContent = 'x'.repeat(1000);
-    setupDriveFolders([
-      makeDriveFile('big.md', '2026-03-15T00:00:00Z'),
-    ]);
     (mockClient.driveRead as ReturnType<typeof vi.fn>).mockResolvedValue({
-      name: 'big.md',
+      name: 'summary.md',
       mime_type: 'text/plain',
-      content: largeContent,
+      content: '# Summary\nInlined.',
     } satisfies DriveReadResult);
 
-    // Budget is tiny but we should still get the first file
-    const result = await loadLifeContext('life-work', 10);
-    expect(result).toContain('## big.md');
-    expect(result).not.toContain('[truncated');
+    const result = await loadLifeContext('life-work');
+    expect(result).toMatch(/- weekly-report\.md /);
+    expect(result).toMatch(/- notes\.md /);
+    expect(result).not.toContain('data.json');
   });
 
   it('works for different agent names', async () => {

--- a/tests/claude-cli.test.ts
+++ b/tests/claude-cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { parseClaudeJsonOutput, buildClaudeArgs, buildToolArgs, friendlyError, runClaude } from '../src/claude-cli.js';
+import { parseClaudeJsonOutput, buildClaudeArgs, buildToolArgs, composeClaudeArgs, friendlyError, runClaude } from '../src/claude-cli.js';
 
 describe('parseClaudeJsonOutput', () => {
   it('extracts result text and session_id from JSON output', () => {
@@ -284,5 +284,58 @@ describe('runClaude timeout', () => {
     const result = runClaude('/tmp', [], 'test', undefined, undefined, 200);
     await expect(result).rejects.toThrow(/timed out/i);
   }, 5_000);
+});
+
+describe('composeClaudeArgs', () => {
+  it('returns a copy of defaults when extras is undefined', () => {
+    const defaults = ['--output-format', 'json'];
+    const result = composeClaudeArgs(defaults, undefined);
+    expect(result).toEqual(['--output-format', 'json']);
+    expect(result).not.toBe(defaults);
+  });
+
+  it('returns a copy of defaults when extras is empty', () => {
+    const defaults = ['--output-format', 'json'];
+    expect(composeClaudeArgs(defaults, [])).toEqual(['--output-format', 'json']);
+  });
+
+  it('concatenates defaults + extras when extras has no permission flags', () => {
+    expect(composeClaudeArgs(['--output-format', 'json'], ['--model', 'opus']))
+      .toEqual(['--output-format', 'json', '--model', 'opus']);
+  });
+
+  it('strips --dangerously-skip-permissions when extras supplies --allowed-tools', () => {
+    const defaults = ['--dangerously-skip-permissions', '--output-format', 'json'];
+    const extras = ['--allowed-tools', 'Read(/vault/topics/hobbies/**)'];
+    expect(composeClaudeArgs(defaults, extras))
+      .toEqual(['--output-format', 'json', '--allowed-tools', 'Read(/vault/topics/hobbies/**)']);
+  });
+
+  it('strips --dangerously-skip-permissions when extras supplies --disallowed-tools', () => {
+    const defaults = ['--dangerously-skip-permissions', '--output-format', 'json'];
+    const extras = ['--disallowed-tools', 'Bash'];
+    expect(composeClaudeArgs(defaults, extras))
+      .toEqual(['--output-format', 'json', '--disallowed-tools', 'Bash']);
+  });
+
+  it('strips --dangerously-skip-permissions when extras supplies --add-dir', () => {
+    const defaults = ['--dangerously-skip-permissions', '--output-format', 'json'];
+    const extras = ['--add-dir', '/vault/_identity'];
+    expect(composeClaudeArgs(defaults, extras))
+      .toEqual(['--output-format', 'json', '--add-dir', '/vault/_identity']);
+  });
+
+  it('keeps --dangerously-skip-permissions when extras has no permission flags', () => {
+    const defaults = ['--dangerously-skip-permissions', '--output-format', 'json'];
+    const extras = ['--model', 'opus'];
+    expect(composeClaudeArgs(defaults, extras))
+      .toEqual(['--dangerously-skip-permissions', '--output-format', 'json', '--model', 'opus']);
+  });
+
+  it('does not mutate the defaults array when stripping', () => {
+    const defaults = ['--dangerously-skip-permissions', '--output-format', 'json'];
+    composeClaudeArgs(defaults, ['--allowed-tools', 'Read(/x/**)']);
+    expect(defaults).toEqual(['--dangerously-skip-permissions', '--output-format', 'json']);
+  });
 });
 

--- a/tests/life-context-loader.test.ts
+++ b/tests/life-context-loader.test.ts
@@ -142,20 +142,22 @@ describe('loadLifeContext', () => {
       delete process.env.BROKER_ACTOR_ID;
     });
 
-    it('returns formatted context string with all three files', async () => {
+    it('emits an index block with summary body inlined and other files listed', async () => {
       setupMockClient();
 
       const result = await loadLifeContext('life-work');
 
       expect(result).not.toBeNull();
-      expect(result).toContain('--- LIFE CONTEXT DATA ---');
-      expect(result).toContain('--- END LIFE CONTEXT DATA ---');
+      expect(result).toContain('--- LIFE CONTEXT INDEX ---');
+      expect(result).toContain('--- END LIFE CONTEXT INDEX ---');
+      // summary.md body is inlined
       expect(result).toContain('## summary.md');
       expect(result).toContain('# Work Summary');
-      expect(result).toContain('## timeline.md');
-      expect(result).toContain('- 2025-01 Started job');
-      expect(result).toContain('## entities.md');
-      expect(result).toContain('## People');
+      // Other files appear by name in the listing, not their bodies
+      expect(result).toMatch(/- timeline\.md /);
+      expect(result).toMatch(/- entities\.md /);
+      expect(result).not.toContain('- 2025-01 Started job');
+      expect(result).not.toContain('## People');
     });
 
     it('skips files not present in folder listing', async () => {


### PR DESCRIPTION
## Summary
- Replaces the 24 KB pre-loaded vault block with a lightweight index (`summary.md` + file listing with sizes/descriptions) so large files like `mountains.md` (104.6 KB) stay reachable instead of being silently dropped.
- Topic agents are scoped to their topic directory by spawning the Claude CLI with `cwd` set to the topic root and `--add-dir <vault>/_identity` for writing-style. This is the enforceable mechanism — `--allowed-tools` path patterns were tried first but do **not** restrict CWD-scoped Read/Grep/Glob.
- Adds `composeClaudeArgs` to strip `--dangerously-skip-permissions` from the gateway defaults whenever an enforcement flag (`--allowed-tools`, `--disallowed-tools`, `--add-dir`) is supplied by the caller — otherwise the gateway default bypasses the check and scoping is a no-op.
- Sensitive-topic isolation preserved: `@life-hobbies` cannot reach `/topics/work` or `/topics/_sensitive/*`; each `_sensitive/<topic>` is isolated from its siblings.

Closes yama-kei/ayumi#64.

## Test plan

**Unit tests** (all green):
- `tests/ayumi/life-context-loader.test.ts` — 29 tests: buildVaultIndex, index-block emission, Drive-path fallback, `getLifeContextRunArgs` scoping, sensitive-topic isolation
- `tests/claude-cli.test.ts` — 40 tests, including 8 new cases for `composeClaudeArgs` (stripping behavior for each permission flag, non-mutation of defaults)
- Full suite: 590/613 pass. The 23 failures are the pre-existing unrelated failures in `tests/activity-engine.test.ts` and `tests/tmux-runtime.test.ts`.

**Empirical probes** (against `/home/yamakei/Documents/ayumi/vault`, CWD = `topics/hobbies`, `--add-dir _identity`):
- [x] In-scope Read succeeds — `./summary.md` → `# Hobbies Summary`
- [x] Cross-topic Read denied — `/topics/work/summary.md` → `permission_denials` populated, no content returned
- [x] Writing-style Read succeeds via `--add-dir` — returns `# Writing Style Profile`
- [x] `..` traversal denied — `hobbies/../work/summary.md` resolved and denied
- [x] Control: with `--dangerously-skip-permissions` left in, cross-topic read succeeds (validates that stripping the flag is load-bearing, not decorative)

**End-to-end mountaineering probe** — the acceptance criterion from the issue:
- Prompt: "What mountains have I climbed in the Hotaka or Tsurugi ranges?"
- Result: agent correctly fetched `mountains.md` on demand and answered with dated, source-attributed entries — 前穂高岳 北尾根 (2005-09-23), 穂高岳 池巡り (2009-09-19), 剱岳 源次郎尾根 (2005-09-19), 八ツ峰 C-face (2007-07-31), 長次郎谷 (2009-07-20). No permission denials. This content was unreachable before because `mountains.md` sorted after the 24 KB budget was exhausted.