### PR TITLE
fix(activity-engine): include 'pending' in sessionTimeline interface, freeze time in tests

### DIFF
--- a/src/activity-engine.ts
+++ b/src/activity-engine.ts
@@ -126,7 +126,7 @@ export interface ActivityEngine {
     segments: Array<{
       start: string;
       end: string;
-      state: 'processing' | 'idle';
+      state: 'processing' | 'idle' | 'pending';
       token_count?: number;
       token_rate?: number;
     }>;

--- a/tests/activity-engine.test.ts
+++ b/tests/activity-engine.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -277,6 +277,16 @@ describe('ActivityEngine', () => {
   });
 
   describe('sessionTimeline', () => {
+    // Tests use hardcoded 2026-03-29 timestamps; freeze system time so readEvents'
+    // range filter (Date.now() - rangeMs) doesn't drop them as time passes.
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-29T16:00:00Z'));
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it('returns empty array for missing file', () => {
       const engine = createActivityEngine(join(dir, 'nonexistent.jsonl'));
       const timeline = engine.sessionTimeline('7d');


### PR DESCRIPTION
## Summary

Two bugs in `src/activity-engine.ts` / `tests/activity-engine.test.ts` introduced by \`ffa05e4\` (fix(dashboard): show pending sessions in timeline view, 2026-04-01):

1. **Type mismatch** — The internal \`Segment\` type gained a \`'pending'\` state, but the public \`ActivityEngine.sessionTimeline\` return type was never widened. Pure oversight → \`npx tsc --noEmit\` fails at \`src/activity-engine.ts:267\`.
2. **Time-dependent tests** — The \`sessionTimeline\` test block uses hardcoded \`2026-03-29T…\` event timestamps, but \`readEvents\` filters by \`Date.now() - rangeMs\`. On merge day those events were 3 days old; today (2026-04-22) they're outside the \`7d\` range and \`sessionTimeline\` returns an empty array for all 21 tests.

## Fix

- \`src/activity-engine.ts\` — widen the interface return type to \`'processing' | 'idle' | 'pending'\` so it matches the internal \`Segment\` type.
- \`tests/activity-engine.test.ts\` — scope \`vi.useFakeTimers()\` + \`vi.setSystemTime('2026-03-29T16:00:00Z')\` to the \`sessionTimeline\` describe block. Tests now run deterministically regardless of when they fire. Other describe blocks keep real time (their event timestamps are generated via \`new Date().toISOString()\`).

## Verification

Before:
- \`npx tsc --noEmit\` → 1 error
- \`npx vitest run tests/activity-engine.test.ts\` → 19 pass / 21 fail
- Full suite → 604 pass / 23 fail (of 627)

After:
- \`npx tsc --noEmit\` → clean
- \`npx vitest run tests/activity-engine.test.ts\` → 40/40 pass
- Full suite → 625 pass / 2 fail (of 627). The remaining 2 are pre-existing \`tmux-runtime\` tests that only fail on machines with \`BROKER_*\` env vars set in the shell — environmental, unrelated to this fix.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run tests/activity-engine.test.ts\` — 40/40 pass
- [x] Full suite passing delta: +21 tests, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)