### PR TITLE
fix(mpg): preserve --allowed-tools when routing life-* agents

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -11,10 +11,10 @@ import { hasAllowedRole } from './role-check.js';
 import { createRateLimiter } from './rate-limiter.js';
 import { downloadAttachments, buildAttachmentPrompt, type AttachmentConfig, DEFAULT_ATTACHMENT_CONFIG } from './attachments.js';
 import type { AgentConfig } from './config.js';
+import { resolveLifeContextRun as resolveLifeContextRunImpl, type GetLifeContextRunArgs } from './life-context-spawn.js';
 // Ayumi life-context module — optional, gracefully absent
 let getAgentContext: (agentName: string) => Promise<string | null> = async () => null;
-interface LifeContextRunArgs { cwd: string; extraArgs: string[] }
-let getLifeContextRunArgs: (agentName: string) => LifeContextRunArgs | null = () => null;
+let getLifeContextRunArgs: GetLifeContextRunArgs = () => null;
 try {
   const ayumi = await import('./ayumi/index.js');
   getAgentContext = ayumi.getAgentContext;
@@ -23,25 +23,12 @@ try {
   // Ayumi module not available — no life context injection
 }
 
-/**
- * Resolve the CLI spawn parameters (cwd + extraArgs) for a send. For a
- * life-context topic agent, the CWD is switched to the topic directory
- * and --add-dir is added so the agent can still read _identity/. For all
- * other agents, the project cwd and gateway-default tool args are used.
- */
 function resolveLifeContextRun(
   agentName: string | undefined,
   defaultCwd: string,
   defaultExtraArgs: string[],
 ): { cwd: string; extraArgs: string[] | undefined } {
-  if (agentName) {
-    const run = getLifeContextRunArgs(agentName);
-    if (run) return { cwd: run.cwd, extraArgs: run.extraArgs };
-  }
-  return {
-    cwd: defaultCwd,
-    extraArgs: defaultExtraArgs.length > 0 ? defaultExtraArgs : undefined,
-  };
+  return resolveLifeContextRunImpl(getLifeContextRunArgs, agentName, defaultCwd, defaultExtraArgs);
 }
 
 // Ayumi curator commands — optional, gracefully absent

--- a/src/life-context-spawn.ts
+++ b/src/life-context-spawn.ts
@@ -1,0 +1,42 @@
+export interface LifeContextRunArgs {
+  cwd: string;
+  extraArgs: string[];
+}
+
+export type GetLifeContextRunArgs = (agentName: string) => LifeContextRunArgs | null;
+
+export interface ResolvedSpawn {
+  cwd: string;
+  extraArgs: string[] | undefined;
+}
+
+/**
+ * Resolve the CLI spawn parameters (cwd + extraArgs) for a send.
+ *
+ * For a life-context topic agent, the CWD is switched to the topic directory
+ * and the life-context extras (notably `--add-dir <_identity>`) are *appended*
+ * to the gateway tool args. Appending (not replacing) preserves
+ * `--allowed-tools` — without it, adding `--add-dir` would silently strip
+ * `--dangerously-skip-permissions` at the claude-cli layer and leave the
+ * agent with no allowlist, denying Bash(gh:*), Bash(git:*), etc.
+ *
+ * For all other agents, the project cwd and gateway-default tool args are
+ * used unchanged.
+ */
+export function resolveLifeContextRun(
+  getLifeContextRunArgs: GetLifeContextRunArgs,
+  agentName: string | undefined,
+  defaultCwd: string,
+  defaultExtraArgs: string[],
+): ResolvedSpawn {
+  if (agentName) {
+    const run = getLifeContextRunArgs(agentName);
+    if (run) {
+      return { cwd: run.cwd, extraArgs: [...defaultExtraArgs, ...run.extraArgs] };
+    }
+  }
+  return {
+    cwd: defaultCwd,
+    extraArgs: defaultExtraArgs.length > 0 ? defaultExtraArgs : undefined,
+  };
+}

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -10,11 +10,11 @@ import type { ChannelAdapter } from './adapter.js';
 import { createRateLimiter } from './rate-limiter.js';
 import type { AgentConfig } from './config.js';
 import { handleCommand } from './discord.js';
+import { resolveLifeContextRun as resolveLifeContextRunImpl, type GetLifeContextRunArgs } from './life-context-spawn.js';
 
 // Ayumi life-context module — optional, gracefully absent
 let getAgentContext: (agentName: string) => Promise<string | null> = async () => null;
-interface LifeContextRunArgs { cwd: string; extraArgs: string[] }
-let getLifeContextRunArgs: (agentName: string) => LifeContextRunArgs | null = () => null;
+let getLifeContextRunArgs: GetLifeContextRunArgs = () => null;
 try {
   const ayumi = await import('./ayumi/index.js');
   getAgentContext = ayumi.getAgentContext;
@@ -23,25 +23,12 @@ try {
   // Ayumi module not available — no life context injection
 }
 
-/**
- * Resolve the CLI spawn parameters (cwd + extraArgs) for a send. For a
- * life-context topic agent, the CWD is switched to the topic directory
- * and --add-dir is added so the agent can still read _identity/. For all
- * other agents, the project cwd and gateway-default tool args are used.
- */
 function resolveLifeContextRun(
   agentName: string | undefined,
   defaultCwd: string,
   defaultExtraArgs: string[],
 ): { cwd: string; extraArgs: string[] | undefined } {
-  if (agentName) {
-    const run = getLifeContextRunArgs(agentName);
-    if (run) return { cwd: run.cwd, extraArgs: run.extraArgs };
-  }
-  return {
-    cwd: defaultCwd,
-    extraArgs: defaultExtraArgs.length > 0 ? defaultExtraArgs : undefined,
-  };
+  return resolveLifeContextRunImpl(getLifeContextRunArgs, agentName, defaultCwd, defaultExtraArgs);
 }
 
 /** Slack message text limit (~4000 chars, with margin). */

--- a/tests/life-context-spawn.test.ts
+++ b/tests/life-context-spawn.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { resolveLifeContextRun } from '../src/life-context-spawn.js';
+
+describe('resolveLifeContextRun', () => {
+  it('appends life-context extras to gateway tool args so --allowed-tools survives for life-* agents', () => {
+    const getRunArgs = (name: string) =>
+      name === 'life-work'
+        ? { cwd: '/vault/topics/work', extraArgs: ['--add-dir', '/vault/_identity'] }
+        : null;
+
+    const result = resolveLifeContextRun(
+      getRunArgs,
+      'life-work',
+      '/project',
+      ['--allowed-tools', 'Read', 'Edit', 'Bash(gh:*)', 'Bash(git:*)'],
+    );
+
+    expect(result.cwd).toBe('/vault/topics/work');
+    expect(result.extraArgs).toEqual([
+      '--allowed-tools', 'Read', 'Edit', 'Bash(gh:*)', 'Bash(git:*)',
+      '--add-dir', '/vault/_identity',
+    ]);
+  });
+
+  it('falls back to project cwd and default extras for non-life agents', () => {
+    const getRunArgs = () => null;
+
+    const result = resolveLifeContextRun(
+      getRunArgs,
+      'pm',
+      '/project',
+      ['--allowed-tools', 'Read'],
+    );
+
+    expect(result.cwd).toBe('/project');
+    expect(result.extraArgs).toEqual(['--allowed-tools', 'Read']);
+  });
+
+  it('returns undefined extraArgs when defaults are empty and no life-context runs', () => {
+    const getRunArgs = () => null;
+
+    const result = resolveLifeContextRun(getRunArgs, undefined, '/project', []);
+
+    expect(result.cwd).toBe('/project');
+    expect(result.extraArgs).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Restore `Bash(gh:*)` / `Bash(git:*)` / `WebFetch` / etc. for life-* topic agents (@life-work, @life-travel, …). Prior to this fix, those agents silently lost the full gateway allowlist and would respond with "I don't have access to the gh command" when asked.
- Extract the `resolveLifeContextRun` helper (duplicated in `src/discord.ts` and `src/slack.ts`) into `src/life-context-spawn.ts` so the behavior can be unit-tested directly.

## Root cause

Commit 6a67a2e introduced CWD + `--add-dir` scoping for life-* agents, but `resolveLifeContextRun` returned **only** `run.extraArgs` (i.e. `['--add-dir', <_identity>]`) and discarded `defaultExtraArgs` (the gateway-built `--allowed-tools …` list).

Downstream in `composeClaudeArgs` (claude-cli.ts:97-104), the presence of `--add-dir` strips `--dangerously-skip-permissions` from the defaults. The resulting argv had **neither** `--dangerously-skip-permissions` **nor** `--allowed-tools`, so the CLI fell back to its headless default: built-in Read/Grep/Glob work CWD-scoped (as the commit's tests confirmed), but `Bash` tool use is denied. `gh`, `git`, `gh pr …`, etc. all get refused.

## Fix

Append life-context extras to the default tool args instead of replacing them:

```ts
extraArgs: [...defaultExtraArgs, ...run.extraArgs]
```

## Test plan

- [x] New regression test `tests/life-context-spawn.test.ts` asserts `--allowed-tools Bash(gh:*) …` survives alongside `--add-dir` for life-* agents.
- [x] `npm test` for touched surfaces (life-context-spawn, life-context-loader, discord, slack) → 73/73 pass.
- [x] `npm run build` passes.
- [ ] Manual: ask a life-* agent to run `gh --version` and confirm it succeeds.

Pre-existing failures in `tests/tmux-runtime.test.ts` (23) are unrelated to this change (verified by stashing and re-running on the base commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)