### PR TITLE
test(tmux-runtime): fix BROKER_* env-leakage failures (closes #221)

### DIFF
--- a/tests/tmux-runtime.test.ts
+++ b/tests/tmux-runtime.test.ts
@@ -97,9 +97,12 @@ describe('TmuxRuntime', () => {
       expect(result.text).toBe('Hello from tmux');
       expect(result.sessionId).toBe('tmux-session-123');
 
-      // Verify script contains timeout wrapper: timeoutMs=5000 + 5min buffer = 305s
+      // Verify script contains timeout wrapper: timeoutMs=5000 + 5min buffer = 305s.
+      // Shebang and `timeout` line are asserted separately so the test is robust
+      // to optional env-export preamble (see tmux-runtime.ts: BROKER_* forwarding).
       const scriptContent = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
-      expect(scriptContent).toMatch(/^#!\/bin\/sh\ntimeout 305 claude /);
+      expect(scriptContent).toMatch(/^#!\/bin\/sh\n/);
+      expect(scriptContent).toMatch(/\ntimeout 305 claude /);
     });
 
     it('uses default timeout (20min + 5min buffer = 1500s) when timeoutMs is omitted', async () => {
@@ -110,7 +113,8 @@ describe('TmuxRuntime', () => {
       await runtime.spawn({ ...spawnOpts, timeoutMs: undefined });
 
       const scriptContent = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
-      expect(scriptContent).toMatch(/^#!\/bin\/sh\ntimeout 1500 claude /);
+      expect(scriptContent).toMatch(/^#!\/bin\/sh\n/);
+      expect(scriptContent).toMatch(/\ntimeout 1500 claude /);
     });
 
     it('kills stale tmux session before launching new one', async () => {


### PR DESCRIPTION
## Summary

Fixes the last 2 failures from #221 by decoupling the `TmuxRuntime.spawn` script-content assertions from an implicit "pristine `process.env`" assumption.

## Scope note (smaller than #221 suggested)

Issue #221 listed **23 failures** (21 `sessionTimeline` + 2 `tmux-runtime`). On current `master` (`4071146`) only the **2 `tmux-runtime`** ones remain — the 21 `sessionTimeline` failures were already fixed by **#218** (`6901696 fix(activity-engine): include 'pending' in sessionTimeline interface, freeze time in tests`), which landed between #221's reproduction commit (`39f7cdc`) and today. Confirmed via a baseline `npm test`:

```
Before this PR:  Test Files 1 failed | 35 passed (36)    Tests 2 failed | 646 passed (648)
After this PR:   Test Files 36 passed (36)               Tests 648 passed (648)
```

So this PR closes #221 by resolving the remaining 2; no action needed on the `sessionTimeline` cluster.

## Root cause

`src/runtimes/tmux-runtime.ts` (lines 68–76) intentionally forwards `BROKER_URL`, `BROKER_API_SECRET`, `BROKER_TENANT_ID`, `BROKER_ACTOR_ID` from `process.env` into the generated tmux script as `export` lines (so the spawned Claude CLI can reach the HouseholdOS broker API used by curator / other Ayumi agents). When any of those vars are set on the parent shell — which is common on any machine configured for ayumi-broker dev — the script becomes:

```
#!/bin/sh
export BROKER_URL='...'
export BROKER_API_SECRET='...'
export BROKER_TENANT_ID='...'
export BROKER_ACTOR_ID='...'
timeout 1500 claude ...
```

…which fails the test's `/^#!\/bin\/sh\ntimeout 1500 claude /` line-2 anchor. The runtime behavior is correct; the **test**'s implicit pristine-env assumption was the fragility.

## Fix

Split the single structural regex into two decoupled assertions:

```ts
expect(scriptContent).toMatch(/^#!\/bin\/sh\n/);        // shebang on line 1
expect(scriptContent).toMatch(/\ntimeout 305 claude /); // `timeout` line-start, anywhere
```

This preserves both structural guarantees the original test cared about (shebang correct, `timeout` appears as a full line with the right value) while being agnostic to any optional preamble — whether the current BROKER_* block, future additions to the env-forwarding list, or other env leakage.

### Why not the alternatives

- **`beforeEach` unsets BROKER_\***: works today but hard-codes the env-var list in the test — if the runtime ever adds another forwarded var, this test silently regresses again.
- **Relax to `.toContain('timeout 1500 claude ')`**: per the #221 suggestion. Robust but loses the "shebang present" and "on its own line" guarantees (would pass if `timeout 1500 claude` appeared mid-line in a comment). The split-regex form retains both.
- **Source-code change (make env-forwarding opt-in)**: out of scope — current behavior is used by curator/Ayumi in prod.

## Verification

Commands run on the branch tip:

- `npx vitest run tests/tmux-runtime.test.ts` → **13 passed (13)** (previously 11 / 2 failed with BROKER_\* set).
- `npm test` → **36 passed (36)** files, **648 passed (648)** tests.

Both previously-failing tests now pass in the BROKER_*-leaked environment (my shell); the regex form is also trivially correct in a pristine env (the export block is simply absent, both anchors still match).

## Test plan
- [x] Both failing tmux-runtime tests now pass with BROKER_* set.
- [x] Full suite green — 648/648, zero regressions.
- [x] Shebang and `timeout` structural guarantees preserved.
- [x] Assertion is robust to future additions to the `BROKER_*` forwarding list.

Closes #221. Refs #218, #220.
