### PR TITLE
fix(#232): tolerate NDJSON Claude CLI output, wrap parse errors

### DIFF
--- a/src/claude-cli.ts
+++ b/src/claude-cli.ts
@@ -22,7 +22,31 @@ export interface ClaudeResult {
 }
 
 export function parseClaudeJsonOutput(raw: string): ClaudeResult {
-  const data = JSON.parse(raw);
+  // Claude CLI normally emits a single JSON object in --output-format=json
+  // mode, but in some long-running scenarios stdout can contain multiple JSON
+  // objects separated by newlines (a status/init frame plus the final result,
+  // two concatenated runs, etc.). Try a single-document parse first; on
+  // failure, fall back to NDJSON parsing and pick the last frame that looks
+  // like a final result.
+  let data: any;
+  try {
+    data = JSON.parse(raw);
+  } catch (err) {
+    const lines = raw.split('\n').map((l) => l.trim()).filter((l) => l.length > 0);
+    let lastResult: any;
+    for (const line of lines) {
+      try {
+        const parsed = JSON.parse(line);
+        if (parsed && typeof parsed === 'object' && 'result' in parsed) {
+          lastResult = parsed;
+        }
+      } catch {
+        // skip malformed lines
+      }
+    }
+    if (!lastResult) throw err;
+    data = lastResult;
+  }
   let usage: ClaudeUsage | undefined;
   if (data.total_cost_usd != null || data.usage) {
     const model = data.model

--- a/src/runtimes/tmux-runtime.ts
+++ b/src/runtimes/tmux-runtime.ts
@@ -210,7 +210,13 @@ export class TmuxRuntime implements AgentRuntime {
             return;
           }
 
-          const result = parseClaudeJsonOutput(stdout);
+          let result: ClaudeResult;
+          try {
+            result = parseClaudeJsonOutput(stdout);
+          } catch {
+            reject(new Error(`Failed to parse claude output: ${stdout.slice(0, 200)}`));
+            return;
+          }
           resolve(result);
         } catch (err) {
           reject(err instanceof Error ? err : new Error(String(err)));

--- a/tests/claude-cli.test.ts
+++ b/tests/claude-cli.test.ts
@@ -32,6 +32,50 @@ describe('parseClaudeJsonOutput', () => {
   it('throws on invalid JSON', () => {
     expect(() => parseClaudeJsonOutput('not json')).toThrow();
   });
+
+  it('tolerates NDJSON with status frame followed by result frame', () => {
+    const status = JSON.stringify({ type: 'system', subtype: 'init', session_id: 'abc' });
+    const result = JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: 'final answer',
+      session_id: 'abc-123',
+    });
+    const parsed = parseClaudeJsonOutput(`${status}\n${result}\n`);
+    expect(parsed.text).toBe('final answer');
+    expect(parsed.sessionId).toBe('abc-123');
+  });
+
+  it('picks the last result frame when multiple result objects are concatenated', () => {
+    const first = JSON.stringify({
+      type: 'result',
+      is_error: false,
+      result: 'old answer',
+      session_id: 'old',
+    });
+    const second = JSON.stringify({
+      type: 'result',
+      is_error: false,
+      result: 'new answer',
+      session_id: 'new',
+    });
+    const parsed = parseClaudeJsonOutput(`${first}\n${second}`);
+    expect(parsed.text).toBe('new answer');
+    expect(parsed.sessionId).toBe('new');
+  });
+
+  it('skips malformed lines but recovers the result frame', () => {
+    const result = JSON.stringify({
+      type: 'result',
+      is_error: false,
+      result: 'recovered',
+      session_id: 'sess',
+    });
+    const parsed = parseClaudeJsonOutput(`garbage line\n${result}\n  \n`);
+    expect(parsed.text).toBe('recovered');
+    expect(parsed.sessionId).toBe('sess');
+  });
 });
 
 describe('parseClaudeJsonOutput — usage extraction', () => {

--- a/tests/tmux-runtime.test.ts
+++ b/tests/tmux-runtime.test.ts
@@ -157,6 +157,32 @@ describe('TmuxRuntime', () => {
 
       await expect(runtime.spawn(spawnOpts)).rejects.toThrow(/no output/i);
     });
+
+    it('wraps unparseable output in a "Failed to parse" error rather than re-throwing the raw SyntaxError', async () => {
+      // Output that is not valid JSON in any form (single or NDJSON).
+      mockSessionExists.mockReturnValue(false);
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue('not json at all');
+
+      await expect(runtime.spawn(spawnOpts)).rejects.toThrow(/Failed to parse claude output:/);
+    });
+
+    it('recovers result from NDJSON output (status frame + result frame)', async () => {
+      const status = JSON.stringify({ type: 'system', subtype: 'init', session_id: 'init' });
+      const result = JSON.stringify({
+        type: 'result',
+        is_error: false,
+        result: 'recovered from ndjson',
+        session_id: 'final',
+      });
+      mockSessionExists.mockReturnValue(false);
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(`${status}\n${result}\n`);
+
+      const r = await runtime.spawn(spawnOpts);
+      expect(r.text).toBe('recovered from ndjson');
+      expect(r.sessionId).toBe('final');
+    });
   });
 
   describe('listOrphanedSessions', () => {


### PR DESCRIPTION
Fixes #232.

## Summary
- `parseClaudeJsonOutput` falls back to NDJSON line-by-line parsing when single-document parse fails, picking the last frame with a `result` field.
- `TmuxRuntime._waitForResult` now wraps parse failures (`Failed to parse claude output: <snippet>`) instead of propagating the raw V8 `SyntaxError` — that bare error was the user-facing `⚠️ Agent @engineer failed: Unexpected non-whitespace character after JSON at position N (line 2 column 1)` reported in the issue.

## Why this path
In `--output-format=json` mode the Claude CLI is *supposed* to emit a single document, but in some long-running scenarios stdout contains multiple JSON objects on separate lines. Both `claude-cli.ts:188` (in-process) and `tmux-runtime.ts:137` (`_readResult`) already wrap their parse errors; only `tmux-runtime.ts:213` (`_waitForResult`, the path used for long-running tmux-mode sessions) re-threw the raw `SyntaxError`. That mismatch is why the bare V8 message only appeared on long tasks.

## Test plan
- [x] `npx vitest run` — 676/676 pass, including 5 new tests covering: status+result NDJSON, two concatenated result frames, malformed-line skipping, the `_waitForResult` wrap, and an integration test for NDJSON recovery through the runtime path.
- [x] `npx tsc --noEmit` — clean.
- [ ] Real-world: monitor next long-running handoff for absence of bare `Unexpected non-whitespace…` message; if a parse failure does still occur, the wrap will now show a `stdout` snippet for forensic root-causing.

## Out of scope
A forensic dump of failing `output.json` files would help us root-cause the upstream "why does the CLI ever emit NDJSON in `--output-format=json` mode" question. Tracked as follow-up in #234 (diagnostic logging on NDJSON fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
