### PR TITLE
feat: gate commands behind allowedRoles + require confirm for !unsafe (#237, #239)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ By default, each Claude session is restricted to its project directory using `--
 - Anyone who can post in a mapped Discord channel can instruct Claude to read and modify files in that project's directory
 - Only map channels that trusted users have access to
 - Tool restrictions are enforced via `--allowed-tools` / `--disallowed-tools` (see [Tool security](#tool-security))
-- When you genuinely need full access for a single session, post `!unsafe` in the Discord channel/thread instead of editing `claudeArgs`. That escalates only that session to `--permission-mode bypassPermissions`, leaves an audit trail in chat, and is reverted with `!safe` (or by restarting the gateway). `--dangerously-skip-permissions` is no longer the recommended default — if it appears in `claudeArgs`, the gateway will warn at startup.
+- When you genuinely need full access for a single session, post `!unsafe` in the Discord channel/thread instead of editing `claudeArgs`. The gateway arms a pending escalation; you must reply `!unsafe confirm` within 60 seconds for it to take effect (any other message — including a non-confirmation `!safe`, a routed prompt, or another command — cancels the pending arm). Once confirmed, that session runs under `--permission-mode bypassPermissions` for the rest of its lifetime; revert with `!safe`. `--dangerously-skip-permissions` is no longer the recommended default — if it appears in `claudeArgs`, the gateway will warn at startup.
+- If `allowedRoles` is set on a project, the role check now gates **all** gateway commands (`!unsafe`, `!safe`, `!kill`, `!restart`, etc.) — not just routed prompts. Users without an allowed role can no longer escalate via `!unsafe`.
 
 ### Tool security
 
@@ -489,8 +490,9 @@ The gateway responds to commands in any mapped Discord channel:
 | `!kill <name>` | Force-close a project's session |
 | `!ask <agent> <message>` | Dispatch a message to a specific agent (shorthand: `!<agent> <message>`) |
 | `!agents` | List available agents for the current project |
-| `!unsafe` | Escalate the current channel/thread to `--permission-mode bypassPermissions` for the rest of the session (full access — leaves an audit trail in chat) |
-| `!safe` | Revert to the curated allowlist for the current channel/thread |
+| `!unsafe` | Arm a bypass-permissions escalation for the current channel/thread. Does **not** change state by itself — must be followed by `!unsafe confirm` within 60s. |
+| `!unsafe confirm` | Confirm a pending `!unsafe` arm. Flips the channel/thread to `--permission-mode bypassPermissions` for the rest of the session. |
+| `!safe` | Revert to the curated allowlist for the current channel/thread; also clears any pending `!unsafe` arm. |
 | `!help` | Show available commands |
 
 ## Web dashboard

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,10 +99,10 @@ flowchart TD
 ### Step-by-step
 
 1. **Discord ingestion** — `discord.ts` receives `MessageCreate` event. Bot messages are ignored.
-2. **Command check** — Messages starting with `!` are checked against built-in commands (`!sessions`, `!help`, `!agents`, `!kill`, `!restart`, `!session`). If matched, the reply is sent and processing stops.
-3. **Agent command parse** — `!ask <agent> <message>` and `!<agent> <message>` are parsed via `agent-dispatch.ts`. Unknown agents get an error listing available agents.
-4. **Channel resolution** — `router.ts` maps the channel ID (or parent channel for threads) to a project config. Unmapped channels are silently ignored.
-5. **Access control** — If the project has `allowedRoles`, `role-check.ts` verifies the sender's Discord roles. If the project has `rateLimitPerUser`, `rate-limiter.ts` checks the sliding window.
+2. **Channel resolution** — `router.ts` maps the channel ID (or parent channel for threads) to a project config. Unmapped channels are silently ignored.
+3. **Access control** — If the project has `allowedRoles`, `role-check.ts` verifies the sender's Discord roles **before** any command or prompt is processed (#237). This gates `!unsafe`/`!kill`/`!restart`/etc. as well as routed prompts. If the project has `rateLimitPerUser`, `rate-limiter.ts` checks the sliding window for routed prompts (commands are not rate-limited).
+4. **Command check** — Messages starting with `!` are checked against built-in commands (`!sessions`, `!help`, `!agents`, `!kill`, `!restart`, `!session`, `!unsafe` / `!unsafe confirm` / `!safe`). If matched, the reply is sent and processing stops.
+5. **Agent command parse** — `!ask <agent> <message>` and `!<agent> <message>` are parsed via `agent-dispatch.ts`. Unknown agents get an error listing available agents.
 6. **Thread management** — Main-channel messages spawn a new thread. Thread messages reply in-place.
 7. **Agent resolution** — The target agent is determined by (in priority order): `!ask`/`!<agent>` command, `@agent` mention in text, or last active agent in the thread.
 8. **Session lookup** — `session-manager.ts` looks up or creates a session keyed by `<threadId>` (no agent) or `<threadId>:<agentName>` (agent session). If a persisted session exists on disk, its session ID is restored for context resume.
@@ -277,7 +277,7 @@ Claude sessions are sandboxed via CLI flags:
 | Mode | How it's set | Capabilities |
 |------|--------------|--------------|
 | **Default** | `--permission-mode acceptEdits` (gateway default) | Read/edit files in project dir; tool calls outside the curated allowlist are denied. Shell commands auto-denied in `--print` mode for tools not in the allowlist. |
-| **Per-session escalation** | `!unsafe` in Discord — flips `--permission-mode bypassPermissions` for that channel/thread until `!safe` | Full Claude permission for the rest of the session. Operator-explicit; never the default. |
+| **Per-session escalation** | `!unsafe` arms a pending escalation; the operator must reply `!unsafe confirm` within 60s (any other message cancels). Once confirmed, `--permission-mode bypassPermissions` is applied for that channel/thread until `!safe`. | Full Claude permission for the rest of the session. Operator-explicit, two-step (#239); never the default. Gated by `allowedRoles` when configured (#237). |
 | **Legacy unrestricted** | `--dangerously-skip-permissions` in `claudeArgs` | Full OS access. Triggers a startup warning pointing at #235; supported for backward compatibility but discouraged. |
 
 ### Tool restrictions
@@ -310,7 +310,7 @@ Defense-in-depth alongside the menu denylist: every Discord/Slack-routed session
 
 Two optional per-project mechanisms:
 
-- **Role ACL** (`allowedRoles`) — List of Discord role names or IDs. If set, only members with a matching role can use the bot in that channel. Checked via `role-check.ts`.
+- **Role ACL** (`allowedRoles`) — List of Discord role names or IDs. If set, only members with a matching role can use the bot in that channel — the check applies to **all** gateway commands (`!unsafe`, `!safe`, `!kill`, `!restart`, etc.) and to routed prompts. Checked via `role-check.ts`.
 - **Rate limiting** (`rateLimitPerUser`) — Maximum messages per minute per user. Uses a 1-minute sliding window in `rate-limiter.ts`. Returns retry-after seconds when exceeded.
 
 ### Trust boundary summary

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -4,7 +4,7 @@ import type { SessionManager } from './session-manager.js';
 import { type GatewayConfig, resolveAgentTimeout } from './config.js';
 import { buildToolArgs } from './claude-cli.js';
 import { applyChatNudge, NON_INTERACTIVE_CHAT_NUDGE } from './chat-nudge.js';
-import { createUnsafeRegistry, UNSAFE_MODE_EXTRA_ARGS, type UnsafeRegistry } from './unsafe-mode.js';
+import { createUnsafeRegistry, UNSAFE_MODE_EXTRA_ARGS, UNSAFE_CONFIRM_WINDOW_MS, type UnsafeRegistry } from './unsafe-mode.js';
 import { parseAgentMention, parseAgentCommand, extractAskTarget, parseHandoffCommand, parseAllHandoffs, parseThreadName, stripThreadName } from './agent-dispatch.js';
 import { sendAgentMessage, buildHandoffEmbed, buildFanOutEmbed } from './embed-format.js';
 import type { TurnCounter } from './turn-counter.js';
@@ -199,14 +199,33 @@ export function handleCommand(
   if (cmd === '!unsafe') {
     if (!unsafe) return null;
     if (!context) return 'Run `!unsafe` in a project channel or thread.';
-    unsafe.enable(context.channelId);
+
+    const subcommand = parts[1]?.toLowerCase();
     const where = context.isThread ? ' (thread)' : '';
-    return `⚠️ Unsafe mode enabled for **${context.projectName}**${where}. Claude has full permission for the rest of this session — use \`!safe\` to revert.`;
+
+    if (subcommand === 'confirm') {
+      if (!unsafe.confirmPending(context.channelId)) {
+        return `**${context.projectName}** — no pending \`!unsafe\` to confirm (or it expired). Run \`!unsafe\` first.`;
+      }
+      unsafe.enable(context.channelId);
+      return `⚠️ Unsafe mode enabled for **${context.projectName}**${where}. Claude has full permission for the rest of this session — use \`!safe\` to revert.`;
+    }
+
+    if (unsafe.isEnabled(context.channelId)) {
+      return `**${context.projectName}**${where} — already in unsafe mode. Use \`!safe\` to revert.`;
+    }
+
+    unsafe.armPending(context.channelId);
+    const seconds = Math.floor(UNSAFE_CONFIRM_WINDOW_MS / 1000);
+    return `⚠️ About to escalate **${context.projectName}**${where} to bypass mode. Reply \`!unsafe confirm\` within ${seconds}s to enable. Any other message cancels.`;
   }
 
   if (cmd === '!safe') {
     if (!unsafe) return null;
     if (!context) return 'Run `!safe` in a project channel or thread.';
+    // De-escalation also drops any pending arm so a leftover prompt doesn't
+    // become confirmable later.
+    unsafe.clearPending(context.channelId);
     if (!unsafe.isEnabled(context.channelId)) {
       return `**${context.projectName}** — already in safe mode.`;
     }
@@ -227,7 +246,8 @@ export function handleCommand(
     ];
     if (unsafe) {
       lines.push(
-        '`!unsafe` — escalate the current session to bypass permissions (full access)',
+        '`!unsafe` — arm a bypass-permissions escalation (must be confirmed)',
+        '`!unsafe confirm` — confirm the pending escalation within 60s',
         '`!safe` — revert the current session to the curated allowlist',
       );
     }
@@ -338,66 +358,16 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
 
     if (!('send' in message.channel)) return;
 
-    // Handle gateway commands from any mapped channel
-    if (message.content.startsWith('!')) {
-      const parentId = message.channel.isThread() ? message.channel.parentId ?? undefined : undefined;
-      const resolved = router.resolve(message.channelId, parentId);
-      if (resolved) {
-        // Handle async !curator commands before sync handleCommand
-        if (message.content.match(/^!curator\b/i)) {
-          if (handleCuratorCommand) {
-            const curatorResponse = await handleCuratorCommand(message.content);
-            if (curatorResponse) {
-              await message.channel.send(curatorResponse);
-              return;
-            }
-          } else {
-            await message.channel.send('Curator commands are not available (ayumi module not installed).');
-            return;
-          }
-        }
-
-        const response = handleCommand(message.content, config, sessionManager, {
-          channelId: resolved.channelId,
-          projectName: resolved.name,
-          isThread: resolved.isThread,
-        }, unsafeRegistry);
-        if (response) {
-          await message.channel.send(response);
-          return;
-        }
-
-        // Check for !ask <agent> or !<agent> shorthand dispatch
-        const projectChannelId = parentId || resolved.channelId;
-        const project = config.projects[projectChannelId];
-        const agents = project?.agents;
-        if (agents) {
-          const askMention = parseAgentCommand(message.content, agents);
-          if (askMention) {
-            // Fall through to normal message handling — inject the parsed mention
-            // by rewriting message content to @agent form so the existing path picks it up
-          } else {
-            // Check if user tried !ask with an unknown agent name
-            const target = extractAskTarget(message.content);
-            if (target) {
-              const agentList = Object.entries(agents)
-                .map(([name, a]) => `\`${name}\` — ${a.role}`)
-                .join('\n- ');
-              await message.channel.send(
-                `Unknown agent \`${target}\`. Available agents:\n- ${agentList}\n\nUsage: \`!ask <agent> <message>\``,
-              );
-              return;
-            }
-          }
-        }
-      }
-    }
-
     const parentId = message.channel.isThread() ? message.channel.parentId ?? undefined : undefined;
     const resolved = router.resolve(message.channelId, parentId);
     if (!resolved) return;
 
-    // Role-based access control
+    // Role-based access control (#237). Gates BOTH gateway commands
+    // (!unsafe / !kill / !restart / etc.) AND routed prompts. Previously
+    // commands ran above this check, which meant any user who could post in
+    // a mapped channel could escalate via !unsafe regardless of allowedRoles.
+    // When a project does not configure allowedRoles, behavior is unchanged
+    // (the predicate short-circuits to allowed).
     const projectChannelIdForAcl = parentId || resolved.channelId;
     const projectForAcl = config.projects[projectChannelIdForAcl];
     if (projectForAcl?.allowedRoles && projectForAcl.allowedRoles.length > 0) {
@@ -407,7 +377,75 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
       }
     }
 
-    // Per-user rate limiting
+    // Pending `!unsafe` arm is cleared by any message that isn't `!unsafe`
+    // (re-arm, refreshes the window inside handleCommand) or `!unsafe confirm`
+    // (consumed inside handleCommand). This is what gives the confirmation
+    // its "any other message cancels" semantic (#239).
+    const trimmedContent = message.content.trim();
+    const isUnsafeArm = trimmedContent.toLowerCase() === '!unsafe';
+    const isUnsafeConfirm = trimmedContent.toLowerCase() === '!unsafe confirm';
+    if (
+      unsafeRegistry.hasPendingArm(resolved.channelId) &&
+      !isUnsafeArm &&
+      !isUnsafeConfirm
+    ) {
+      unsafeRegistry.clearPending(resolved.channelId);
+    }
+
+    // Handle gateway commands from any mapped channel
+    if (message.content.startsWith('!')) {
+      // Handle async !curator commands before sync handleCommand
+      if (message.content.match(/^!curator\b/i)) {
+        if (handleCuratorCommand) {
+          const curatorResponse = await handleCuratorCommand(message.content);
+          if (curatorResponse) {
+            await message.channel.send(curatorResponse);
+            return;
+          }
+        } else {
+          await message.channel.send('Curator commands are not available (ayumi module not installed).');
+          return;
+        }
+      }
+
+      const response = handleCommand(message.content, config, sessionManager, {
+        channelId: resolved.channelId,
+        projectName: resolved.name,
+        isThread: resolved.isThread,
+      }, unsafeRegistry);
+      if (response) {
+        await message.channel.send(response);
+        return;
+      }
+
+      // Check for !ask <agent> or !<agent> shorthand dispatch
+      const projectChannelId = parentId || resolved.channelId;
+      const project = config.projects[projectChannelId];
+      const agents = project?.agents;
+      if (agents) {
+        const askMention = parseAgentCommand(message.content, agents);
+        if (askMention) {
+          // Fall through to normal message handling — inject the parsed mention
+          // by rewriting message content to @agent form so the existing path picks it up
+        } else {
+          // Check if user tried !ask with an unknown agent name
+          const target = extractAskTarget(message.content);
+          if (target) {
+            const agentList = Object.entries(agents)
+              .map(([name, a]) => `\`${name}\` — ${a.role}`)
+              .join('\n- ');
+            await message.channel.send(
+              `Unknown agent \`${target}\`. Available agents:\n- ${agentList}\n\nUsage: \`!ask <agent> <message>\``,
+            );
+            return;
+          }
+        }
+      }
+    }
+
+    // Per-user rate limiting (applies to routed prompts; commands are
+    // intentionally not rate-limited since !sessions / !session etc. are
+    // expected to be issued back-to-back).
     if (projectForAcl?.rateLimitPerUser) {
       const result = rateLimiter.check(`${message.author.id}:${projectChannelIdForAcl}`, projectForAcl.rateLimitPerUser);
       if (!result.allowed) {

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -42,6 +42,21 @@ try {
   // Ayumi module not available — curator commands disabled
 }
 
+/**
+ * Classify a Discord message body in terms of `!unsafe` intent. Used by the
+ * `MessageCreate` handler's pre-clear logic so the "any message except an
+ * arm/confirm clears the pending arm" semantic stays in sync with how
+ * `handleCommand` parses commands (whitespace-tolerant tokenization).
+ */
+export type UnsafeIntent = 'arm' | 'confirm' | 'other';
+export function classifyUnsafeIntent(content: string): UnsafeIntent {
+  const tokens = content.trim().toLowerCase().split(/\s+/);
+  if (tokens[0] !== '!unsafe') return 'other';
+  if (tokens.length === 1) return 'arm';
+  if (tokens[1] === 'confirm') return 'confirm';
+  return 'other';
+}
+
 export function chunkMessage(text: string, limit: number): string[] {
   if (text.length <= limit) return [text];
 
@@ -380,15 +395,12 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
     // Pending `!unsafe` arm is cleared by any message that isn't `!unsafe`
     // (re-arm, refreshes the window inside handleCommand) or `!unsafe confirm`
     // (consumed inside handleCommand). This is what gives the confirmation
-    // its "any other message cancels" semantic (#239).
-    const trimmedContent = message.content.trim();
-    const isUnsafeArm = trimmedContent.toLowerCase() === '!unsafe';
-    const isUnsafeConfirm = trimmedContent.toLowerCase() === '!unsafe confirm';
-    if (
-      unsafeRegistry.hasPendingArm(resolved.channelId) &&
-      !isUnsafeArm &&
-      !isUnsafeConfirm
-    ) {
+    // its "any other message cancels" semantic (#239). `classifyUnsafeIntent`
+    // is whitespace-tolerant to match `handleCommand`'s parser — otherwise
+    // `!unsafe  confirm` (double space, tab, etc.) would silently drop the
+    // arm before the parser saw the confirm intent.
+    const intent = classifyUnsafeIntent(message.content);
+    if (intent === 'other' && unsafeRegistry.hasPendingArm(resolved.channelId)) {
       unsafeRegistry.clearPending(resolved.channelId);
     }
 

--- a/src/unsafe-mode.ts
+++ b/src/unsafe-mode.ts
@@ -7,7 +7,22 @@
  * `!safe` flips it back. State is in-memory only and doesn't persist across
  * gateway restarts; that's intentional — if the operator restarted the
  * gateway, they should re-confirm the escalation.
+ *
+ * Escalation requires explicit confirmation (#239): bare `!unsafe` only arms
+ * a pending intent; the next message in the same channel must be
+ * `!unsafe confirm` (within `UNSAFE_CONFIRM_WINDOW_MS`) to actually flip the
+ * registry. Any other message — including a re-typed `!unsafe`, which
+ * refreshes the window — clears or replaces the pending arm. This prevents a
+ * single typo from granting bypass-permissions for the rest of the session.
  */
+
+/** Default confirmation window for `!unsafe` → `!unsafe confirm` (60 seconds). */
+export const UNSAFE_CONFIRM_WINDOW_MS = 60_000;
+
+interface PendingArm {
+  armedAt: number;
+}
+
 export interface UnsafeRegistry {
   /** Mark a channel/thread as unsafe-mode for the rest of the session. */
   enable(channelId: string): void;
@@ -17,6 +32,35 @@ export interface UnsafeRegistry {
   isEnabled(channelId: string): boolean;
   /** All channels currently in unsafe mode (used by tests/diagnostics). */
   list(): string[];
+
+  /**
+   * Arm a pending escalation. The operator must follow up with
+   * `confirmPending()` within the configured window. Re-arming the same
+   * channel resets the window (so a user who fat-fingered the command can
+   * just retype `!unsafe` without waiting for expiry).
+   */
+  armPending(channelId: string): void;
+  /**
+   * Consume a pending arm. Returns `true` only when a non-expired arm
+   * existed; the arm is removed in either case so a stale entry can't
+   * silently linger. The caller is responsible for calling `enable()` on
+   * a successful confirmation.
+   */
+  confirmPending(channelId: string): boolean;
+  /** Drop any pending arm for this channel. No-op if no arm is set. */
+  clearPending(channelId: string): void;
+  /**
+   * Whether a non-expired pending arm exists for this channel. Expired
+   * entries are evicted as a side effect.
+   */
+  hasPendingArm(channelId: string): boolean;
+}
+
+export interface UnsafeRegistryOptions {
+  /** Confirmation window in ms. Defaults to {@link UNSAFE_CONFIRM_WINDOW_MS}. */
+  windowMs?: number;
+  /** Time source — defaults to `Date.now`. Tests can inject a controllable clock. */
+  now?: () => number;
 }
 
 /**
@@ -28,8 +72,16 @@ export interface UnsafeRegistry {
  */
 export const UNSAFE_MODE_EXTRA_ARGS: string[] = ['--permission-mode', 'bypassPermissions'];
 
-export function createUnsafeRegistry(): UnsafeRegistry {
+export function createUnsafeRegistry(opts?: UnsafeRegistryOptions): UnsafeRegistry {
+  const windowMs = opts?.windowMs ?? UNSAFE_CONFIRM_WINDOW_MS;
+  const now = opts?.now ?? (() => Date.now());
   const enabled = new Set<string>();
+  const pending = new Map<string, PendingArm>();
+
+  function isFresh(armedAt: number): boolean {
+    return now() - armedAt < windowMs;
+  }
+
   return {
     enable(channelId) {
       enabled.add(channelId);
@@ -42,6 +94,28 @@ export function createUnsafeRegistry(): UnsafeRegistry {
     },
     list() {
       return [...enabled];
+    },
+
+    armPending(channelId) {
+      pending.set(channelId, { armedAt: now() });
+    },
+    confirmPending(channelId) {
+      const arm = pending.get(channelId);
+      if (!arm) return false;
+      pending.delete(channelId);
+      return isFresh(arm.armedAt);
+    },
+    clearPending(channelId) {
+      pending.delete(channelId);
+    },
+    hasPendingArm(channelId) {
+      const arm = pending.get(channelId);
+      if (!arm) return false;
+      if (!isFresh(arm.armedAt)) {
+        pending.delete(channelId);
+        return false;
+      }
+      return true;
     },
   };
 }

--- a/src/unsafe-mode.ts
+++ b/src/unsafe-mode.ts
@@ -42,9 +42,11 @@ export interface UnsafeRegistry {
   armPending(channelId: string): void;
   /**
    * Consume a pending arm. Returns `true` only when a non-expired arm
-   * existed; the arm is removed in either case so a stale entry can't
-   * silently linger. The caller is responsible for calling `enable()` on
-   * a successful confirmation.
+   * existed; the arm is **always removed** by this call (even when expired
+   * or never set), so a stale entry can't silently linger and a follow-up
+   * `confirmPending` in the same channel always starts from a clean slate.
+   * The caller is responsible for calling `enable()` on a successful
+   * confirmation.
    */
   confirmPending(channelId: string): boolean;
   /** Drop any pending arm for this channel. No-op if no arm is set. */

--- a/tests/discord.test.ts
+++ b/tests/discord.test.ts
@@ -262,9 +262,9 @@ describe('handleCommand', () => {
     expect(result).toContain('engineer');
   });
 
-  // --- !unsafe / !safe ---
+  // --- !unsafe / !safe (#235, #239) ---
 
-  it('!unsafe enables unsafe mode for the current channel and acks', () => {
+  it('!unsafe arms a pending escalation and asks for confirmation (no state change)', () => {
     const sm = mockSessionManager();
     const unsafe = createUnsafeRegistry();
     const result = handleCommand('!unsafe', testConfig, sm, {
@@ -272,12 +272,13 @@ describe('handleCommand', () => {
       projectName: 'Alpha',
       isThread: false,
     }, unsafe);
-    expect(result).toMatch(/unsafe mode enabled/i);
+    expect(result).toMatch(/!unsafe confirm/i);
     expect(result).toContain('Alpha');
-    expect(unsafe.isEnabled('ch-1')).toBe(true);
+    expect(unsafe.isEnabled('ch-1')).toBe(false);     // not enabled yet
+    expect(unsafe.hasPendingArm('ch-1')).toBe(true);  // arm recorded
   });
 
-  it('!unsafe in a thread enables for the thread channel id', () => {
+  it('!unsafe in a thread arms the thread channel id (not the parent)', () => {
     const sm = mockSessionManager();
     const unsafe = createUnsafeRegistry();
     handleCommand('!unsafe', testConfig, sm, {
@@ -285,8 +286,59 @@ describe('handleCommand', () => {
       projectName: 'Alpha',
       isThread: true,
     }, unsafe);
-    expect(unsafe.isEnabled('thread-99')).toBe(true);
+    expect(unsafe.hasPendingArm('thread-99')).toBe(true);
+    expect(unsafe.hasPendingArm('ch-1')).toBe(false);
+    expect(unsafe.isEnabled('thread-99')).toBe(false);
+  });
+
+  it('!unsafe confirm within window enables and acks', () => {
+    const sm = mockSessionManager();
+    const unsafe = createUnsafeRegistry();
+    handleCommand('!unsafe', testConfig, sm, {
+      channelId: 'ch-1', projectName: 'Alpha', isThread: false,
+    }, unsafe);
+    const result = handleCommand('!unsafe confirm', testConfig, sm, {
+      channelId: 'ch-1', projectName: 'Alpha', isThread: false,
+    }, unsafe);
+    expect(result).toMatch(/unsafe mode enabled/i);
+    expect(unsafe.isEnabled('ch-1')).toBe(true);
+    expect(unsafe.hasPendingArm('ch-1')).toBe(false);
+  });
+
+  it('!unsafe confirm without prior !unsafe returns a no-pending error', () => {
+    const sm = mockSessionManager();
+    const unsafe = createUnsafeRegistry();
+    const result = handleCommand('!unsafe confirm', testConfig, sm, {
+      channelId: 'ch-1', projectName: 'Alpha', isThread: false,
+    }, unsafe);
+    expect(result).toMatch(/no pending|expired/i);
     expect(unsafe.isEnabled('ch-1')).toBe(false);
+  });
+
+  it('!unsafe confirm after the window expires does NOT enable', () => {
+    const sm = mockSessionManager();
+    let t = 1_000_000;
+    const unsafe = createUnsafeRegistry({ now: () => t, windowMs: 1_000 });
+    handleCommand('!unsafe', testConfig, sm, {
+      channelId: 'ch-1', projectName: 'Alpha', isThread: false,
+    }, unsafe);
+    t += 2_000; // past window
+    const result = handleCommand('!unsafe confirm', testConfig, sm, {
+      channelId: 'ch-1', projectName: 'Alpha', isThread: false,
+    }, unsafe);
+    expect(result).toMatch(/no pending|expired/i);
+    expect(unsafe.isEnabled('ch-1')).toBe(false);
+  });
+
+  it('!unsafe when already enabled informs the operator and does NOT arm', () => {
+    const sm = mockSessionManager();
+    const unsafe = createUnsafeRegistry();
+    unsafe.enable('ch-1');
+    const result = handleCommand('!unsafe', testConfig, sm, {
+      channelId: 'ch-1', projectName: 'Alpha', isThread: false,
+    }, unsafe);
+    expect(result).toMatch(/already in unsafe mode/i);
+    expect(unsafe.hasPendingArm('ch-1')).toBe(false);
   });
 
   it('!safe disables unsafe mode and acks', () => {
@@ -313,6 +365,16 @@ describe('handleCommand', () => {
     expect(result).toMatch(/already in safe mode/i);
   });
 
+  it('!safe also clears any pending arm', () => {
+    const sm = mockSessionManager();
+    const unsafe = createUnsafeRegistry();
+    unsafe.armPending('ch-1');
+    handleCommand('!safe', testConfig, sm, {
+      channelId: 'ch-1', projectName: 'Alpha', isThread: false,
+    }, unsafe);
+    expect(unsafe.hasPendingArm('ch-1')).toBe(false);
+  });
+
   it('!unsafe without context returns a usage hint', () => {
     const sm = mockSessionManager();
     const unsafe = createUnsafeRegistry();
@@ -331,11 +393,12 @@ describe('handleCommand', () => {
     expect(result).toBeNull();
   });
 
-  it('!help mentions !unsafe / !safe when registry support is present', () => {
+  it('!help mentions !unsafe / !unsafe confirm / !safe when registry support is present', () => {
     const sm = mockSessionManager();
     const unsafe = createUnsafeRegistry();
     const result = handleCommand('!help', testConfig, sm, undefined, unsafe);
     expect(result).toContain('!unsafe');
+    expect(result).toContain('!unsafe confirm');
     expect(result).toContain('!safe');
   });
 

--- a/tests/discord.test.ts
+++ b/tests/discord.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { chunkMessage, handleCommand } from '../src/discord.js';
+import { chunkMessage, handleCommand, classifyUnsafeIntent } from '../src/discord.js';
 import type { GatewayConfig, AgentConfig } from '../src/config.js';
 import type { SessionManager } from '../src/session-manager.js';
 import { parseAgentMention, parseHandoffCommand } from '../src/agent-dispatch.js';
@@ -31,6 +31,49 @@ function mockSessionManager(sessions: ReturnType<SessionManager['listSessions']>
     shutdown: () => {},
   };
 }
+
+describe('classifyUnsafeIntent', () => {
+  it('classifies bare `!unsafe` as arm', () => {
+    expect(classifyUnsafeIntent('!unsafe')).toBe('arm');
+  });
+
+  it('classifies `!unsafe confirm` as confirm', () => {
+    expect(classifyUnsafeIntent('!unsafe confirm')).toBe('confirm');
+  });
+
+  it('is case-insensitive', () => {
+    expect(classifyUnsafeIntent('!UNSAFE')).toBe('arm');
+    expect(classifyUnsafeIntent('!Unsafe Confirm')).toBe('confirm');
+  });
+
+  it('is whitespace-tolerant — double space between !unsafe and confirm still parses as confirm', () => {
+    expect(classifyUnsafeIntent('!unsafe  confirm')).toBe('confirm');
+  });
+
+  it('is whitespace-tolerant — tab separator still parses as confirm', () => {
+    expect(classifyUnsafeIntent('!unsafe\tconfirm')).toBe('confirm');
+  });
+
+  it('trims leading/trailing whitespace', () => {
+    expect(classifyUnsafeIntent('   !unsafe   ')).toBe('arm');
+    expect(classifyUnsafeIntent('  !unsafe confirm  ')).toBe('confirm');
+  });
+
+  it('classifies unrelated commands as other', () => {
+    expect(classifyUnsafeIntent('!safe')).toBe('other');
+    expect(classifyUnsafeIntent('!sessions')).toBe('other');
+    expect(classifyUnsafeIntent('hello world')).toBe('other');
+    expect(classifyUnsafeIntent('')).toBe('other');
+  });
+
+  it('classifies `!unsafe <other>` (non-confirm subcommand) as other — pre-clear treats it like a regular message', () => {
+    expect(classifyUnsafeIntent('!unsafe foo')).toBe('other');
+  });
+
+  it('classifies `!unsafe foo confirm` as other — confirm must be the second token', () => {
+    expect(classifyUnsafeIntent('!unsafe foo confirm')).toBe('other');
+  });
+});
 
 describe('chunkMessage', () => {
   it('returns a single chunk for short messages', () => {

--- a/tests/unsafe-mode.test.ts
+++ b/tests/unsafe-mode.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createUnsafeRegistry, UNSAFE_MODE_EXTRA_ARGS } from '../src/unsafe-mode.js';
+import { createUnsafeRegistry, UNSAFE_MODE_EXTRA_ARGS, UNSAFE_CONFIRM_WINDOW_MS } from '../src/unsafe-mode.js';
 
 describe('createUnsafeRegistry', () => {
   it('starts with no enabled channels', () => {
@@ -52,5 +52,105 @@ describe('createUnsafeRegistry', () => {
 describe('UNSAFE_MODE_EXTRA_ARGS', () => {
   it('uses --permission-mode bypassPermissions to escalate the session', () => {
     expect(UNSAFE_MODE_EXTRA_ARGS).toEqual(['--permission-mode', 'bypassPermissions']);
+  });
+});
+
+describe('UNSAFE_CONFIRM_WINDOW_MS', () => {
+  it('defaults to 60 seconds', () => {
+    expect(UNSAFE_CONFIRM_WINDOW_MS).toBe(60_000);
+  });
+});
+
+describe('createUnsafeRegistry — pending arm / confirmation flow (#239)', () => {
+  // A controllable clock makes time-based behavior deterministic without
+  // pulling vitest's fake-timer infrastructure into a registry that has no
+  // other timer use.
+  function clock(start = 1_000_000) {
+    let t = start;
+    return {
+      now: () => t,
+      advance(ms: number) { t += ms; },
+    };
+  }
+
+  it('starts with no pending arms', () => {
+    const reg = createUnsafeRegistry();
+    expect(reg.hasPendingArm('chan-1')).toBe(false);
+  });
+
+  it('armPending records a pending arm visible via hasPendingArm', () => {
+    const reg = createUnsafeRegistry();
+    reg.armPending('chan-1');
+    expect(reg.hasPendingArm('chan-1')).toBe(true);
+  });
+
+  it('armPending does NOT enable the channel by itself', () => {
+    const reg = createUnsafeRegistry();
+    reg.armPending('chan-1');
+    expect(reg.isEnabled('chan-1')).toBe(false);
+  });
+
+  it('confirmPending returns true and consumes the pending arm when fresh', () => {
+    const reg = createUnsafeRegistry();
+    reg.armPending('chan-1');
+    expect(reg.confirmPending('chan-1')).toBe(true);
+    expect(reg.hasPendingArm('chan-1')).toBe(false);
+  });
+
+  it('confirmPending returns false when no arm exists', () => {
+    const reg = createUnsafeRegistry();
+    expect(reg.confirmPending('chan-1')).toBe(false);
+  });
+
+  it('confirmPending returns false (and consumes) once the window expires', () => {
+    const c = clock();
+    const reg = createUnsafeRegistry({ now: c.now, windowMs: 60_000 });
+    reg.armPending('chan-1');
+    c.advance(60_001);
+    expect(reg.confirmPending('chan-1')).toBe(false);
+    // Stale entry is also evicted so the next call sees a clean slate.
+    expect(reg.hasPendingArm('chan-1')).toBe(false);
+  });
+
+  it('hasPendingArm auto-evicts expired arms', () => {
+    const c = clock();
+    const reg = createUnsafeRegistry({ now: c.now, windowMs: 1_000 });
+    reg.armPending('chan-1');
+    expect(reg.hasPendingArm('chan-1')).toBe(true);
+    c.advance(1_500);
+    expect(reg.hasPendingArm('chan-1')).toBe(false);
+  });
+
+  it('re-arming the same channel refreshes the window', () => {
+    const c = clock();
+    const reg = createUnsafeRegistry({ now: c.now, windowMs: 1_000 });
+    reg.armPending('chan-1');
+    c.advance(900);                  // 100ms left on the original arm
+    reg.armPending('chan-1');         // refresh
+    c.advance(900);                  // would have expired the original; refreshed arm has 100ms left
+    expect(reg.hasPendingArm('chan-1')).toBe(true);
+    expect(reg.confirmPending('chan-1')).toBe(true);
+  });
+
+  it('clearPending drops a pending arm without confirming', () => {
+    const reg = createUnsafeRegistry();
+    reg.armPending('chan-1');
+    reg.clearPending('chan-1');
+    expect(reg.hasPendingArm('chan-1')).toBe(false);
+    expect(reg.confirmPending('chan-1')).toBe(false);
+  });
+
+  it('clearPending is a no-op when no arm exists', () => {
+    const reg = createUnsafeRegistry();
+    expect(() => reg.clearPending('chan-x')).not.toThrow();
+  });
+
+  it('pending arms are isolated per channel', () => {
+    const reg = createUnsafeRegistry();
+    reg.armPending('chan-1');
+    expect(reg.hasPendingArm('chan-1')).toBe(true);
+    expect(reg.hasPendingArm('chan-2')).toBe(false);
+    expect(reg.confirmPending('chan-2')).toBe(false);
+    expect(reg.hasPendingArm('chan-1')).toBe(true); // unaffected
   });
 });


### PR DESCRIPTION
## Summary

Two related hardenings of the `!unsafe` escalation surface introduced in #235.

- **#237** — `allowedRoles` ACL now gates **all** gateway commands (`!unsafe`, `!safe`, `!kill`, `!restart`, etc.) in addition to routed prompts. Previously commands ran ahead of the role check in `src/discord.ts`, so anyone able to post in a mapped channel could escalate via `!unsafe` regardless of role configuration.
- **#239** — Bare `!unsafe` now arms a pending escalation; the operator must post `!unsafe confirm` in the same channel/thread within 60 seconds for the registry to flip to bypass mode. Any other message — a re-typed `!unsafe` (which refreshes the window), `!safe`, an unrelated command, or a normal prompt — clears or replaces the pending arm. `!safe` continues to work without confirmation and also clears any pending arm. A single typo can no longer escalate to full OS access.

## Changes

- `src/unsafe-mode.ts` — `UnsafeRegistry` gains `armPending` / `confirmPending` / `clearPending` / `hasPendingArm`. `UNSAFE_CONFIRM_WINDOW_MS = 60_000` exported. Constructor takes an optional `now` clock injection for deterministic tests.
- `src/discord.ts` —
  - `MessageCreate` handler now resolves the channel once at the top, runs the role ACL **before** the command branch, and only then dispatches to commands or routed prompts.
  - Pending-arm clearance lives in the handler: any message that is not `!unsafe` (re-arm) or `!unsafe confirm` clears the channel's pending arm.
  - `handleCommand` rewrites `!unsafe`: bare → `armPending` + reply with 60s prompt; `!unsafe confirm` → `confirmPending` then `enable`; already-enabled → informs the operator without arming.
  - `!safe` clears any pending arm before deciding whether to disable.
  - `!help` updated.
- Docs — README (security model + commands table) and `docs/ARCHITECTURE.md` (request flow + escalation row + ACL row) describe the two-step `!unsafe` flow and the broadened ACL coverage.

## Test plan

- [x] `npm test` — **723/723 passing**, including:
  - 12 new `UnsafeRegistry` pending-arm tests (arm, fresh confirm, expired confirm, re-arm refresh, clear, channel isolation, auto-eviction, `armPending` does NOT enable).
  - 6 new `handleCommand` tests (arm-without-state-change, confirm-within-window, confirm-without-prior, confirm-after-expiry, already-enabled informs and doesn't arm, `!safe` clears pending).
  - Existing `!unsafe` / `!safe` tests updated to the new flow.
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [ ] Manual smoke: confirm flow works end-to-end in a real Discord channel; `allowedRoles`-gated channel rejects `!unsafe` from a non-allowed user.

## Notes for the reviewer

**ACL placement is verified by code inspection.** The role-decision predicate (`hasAllowedRole`) has comprehensive unit tests in `tests/role-check.test.ts`. Building an end-to-end message-handler test would require mocking the Discord `Client`, which isn't done elsewhere in this repo; the handler refactor is small and self-evident in the diff. Happy to add an integration harness if the team wants one.

**Reuses `allowedRoles` rather than introducing `adminRoles`** per the PM's recommendation in the dispatch — keeps the config surface small. We can split into `adminRoles` later if a real "everyone can talk, only some can escalate" scenario emerges.

**Out of scope:** #238 (thread-level `!safe` should override parent `!unsafe`) — left for a follow-up. Rate-limiting placement is unchanged (still routed-prompts only); commands remain un-rate-limited so quick `!sessions` / `!session foo` sequences keep working.

Closes #237
Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)