### PR TITLE
fix: thread-level !safe overrides parent channel unsafe (#238)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ By default, each Claude session is restricted to its project directory using `--
 - Tool restrictions are enforced via `--allowed-tools` / `--disallowed-tools` (see [Tool security](#tool-security))
 - When you genuinely need full access for a single session, post `!unsafe` in the Discord channel/thread instead of editing `claudeArgs`. The gateway arms a pending escalation; you must reply `!unsafe confirm` within 60 seconds for it to take effect (any other message — including a non-confirmation `!safe`, a routed prompt, or another command — cancels the pending arm). Once confirmed, that session runs under `--permission-mode bypassPermissions` for the rest of its lifetime; revert with `!safe`. `--dangerously-skip-permissions` is no longer the recommended default — if it appears in `claudeArgs`, the gateway will warn at startup.
 - If `allowedRoles` is set on a project, the role check now gates **all** gateway commands (`!unsafe`, `!safe`, `!kill`, `!restart`, etc.) — not just routed prompts. Users without an allowed role can no longer escalate via `!unsafe`.
+- `!unsafe` confirmed in a parent channel propagates to threads created in it. To opt a single thread *out* of inherited unsafe without disabling the parent, post `!safe` inside that thread — the thread is then force-safed for the rest of the session unless `!unsafe` is run inside that thread itself, while siblings continue to inherit the parent's escalation (#238).
 
 ### Tool security
 
@@ -492,7 +493,7 @@ The gateway responds to commands in any mapped Discord channel:
 | `!agents` | List available agents for the current project |
 | `!unsafe` | Arm a bypass-permissions escalation for the current channel/thread. Does **not** change state by itself — must be followed by `!unsafe confirm` within 60s. |
 | `!unsafe confirm` | Confirm a pending `!unsafe` arm. Flips the channel/thread to `--permission-mode bypassPermissions` for the rest of the session. |
-| `!safe` | Revert to the curated allowlist for the current channel/thread; also clears any pending `!unsafe` arm. |
+| `!safe` | Revert to the curated allowlist for the current channel/thread; also clears any pending `!unsafe` arm. Inside a thread whose parent channel is in unsafe mode, this force-safes the thread without affecting the parent (#238). |
 | `!help` | Show available commands |
 
 ## Web dashboard

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -277,7 +277,7 @@ Claude sessions are sandboxed via CLI flags:
 | Mode | How it's set | Capabilities |
 |------|--------------|--------------|
 | **Default** | `--permission-mode acceptEdits` (gateway default) | Read/edit files in project dir; tool calls outside the curated allowlist are denied. Shell commands auto-denied in `--print` mode for tools not in the allowlist. |
-| **Per-session escalation** | `!unsafe` arms a pending escalation; the operator must reply `!unsafe confirm` within 60s (any other message cancels). Once confirmed, `--permission-mode bypassPermissions` is applied for that channel/thread until `!safe`. | Full Claude permission for the rest of the session. Operator-explicit, two-step (#239); never the default. Gated by `allowedRoles` when configured (#237). |
+| **Per-session escalation** | `!unsafe` arms a pending escalation; the operator must reply `!unsafe confirm` within 60s (any other message cancels). Once confirmed, `--permission-mode bypassPermissions` is applied for that channel/thread until `!safe`. Threads inherit unsafe mode from their parent channel; `!safe` inside a thread sets a per-thread force-safe override that wins over inheritance (#238). | Full Claude permission for the rest of the session. Operator-explicit, two-step (#239); never the default. Gated by `allowedRoles` when configured (#237). |
 | **Legacy unrestricted** | `--dangerously-skip-permissions` in `claudeArgs` | Full OS access. Triggers a startup warning pointing at #235; supported for backward compatibility but discouraged. |
 
 ### Tool restrictions

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -120,11 +120,23 @@ function formatTimeSince(timestamp: number): string {
   return `${hours}h ${minutes % 60}m ago`;
 }
 
+export interface CommandContext {
+  channelId: string;
+  projectName: string;
+  isThread: boolean;
+  /**
+   * The parent project channel ID when the command is run from a thread.
+   * Required for thread-aware commands like `!safe` to query the parent's
+   * unsafe state and override inherited escalation (#238).
+   */
+  parentChannelId?: string;
+}
+
 export function handleCommand(
   command: string,
   config: GatewayConfig,
   sessionManager: SessionManager,
-  context?: { channelId: string; projectName: string; isThread: boolean },
+  context?: CommandContext,
   unsafe?: UnsafeRegistry,
 ): string | null {
   const parts = command.trim().split(/\s+/);
@@ -238,14 +250,40 @@ export function handleCommand(
   if (cmd === '!safe') {
     if (!unsafe) return null;
     if (!context) return 'Run `!safe` in a project channel or thread.';
-    // De-escalation also drops any pending arm so a leftover prompt doesn't
-    // become confirmable later.
+
+    // De-escalation also drops any pending !unsafe arm so a leftover prompt
+    // doesn't become confirmable later (#239).
     unsafe.clearPending(context.channelId);
-    if (!unsafe.isEnabled(context.channelId)) {
-      return `**${context.projectName}** — already in safe mode.`;
+
+    const parentStillUnsafe =
+      context.isThread &&
+      context.parentChannelId !== undefined &&
+      unsafe.isEnabled(context.parentChannelId);
+
+    // Channel/thread itself is enabled — disable. If the parent is also
+    // enabled (so the next prompt would still inherit unsafe), additionally
+    // set the force-safe override and surface that to the operator (#238 +
+    // both-enabled edge case from PR #241 review).
+    if (unsafe.isEnabled(context.channelId)) {
+      unsafe.disable(context.channelId);
+      if (parentStillUnsafe) {
+        unsafe.setForceSafe(context.channelId);
+        return `✅ Thread disabled and overridden to safe mode for **${context.projectName}**. Parent channel is still in unsafe mode — run \`!safe\` there to revert it for the whole project.`;
+      }
+      return `✅ Safe mode restored for **${context.projectName}**.`;
     }
-    unsafe.disable(context.channelId);
-    return `✅ Safe mode restored for **${context.projectName}**.`;
+
+    // Thread inheriting unsafe from its parent: the operator wants this
+    // thread safe but the parent's escalation should stay in effect for
+    // siblings. Set a per-thread force-safe override (#238). Without this
+    // branch, `!safe` here was a silent no-op since `disable()` couldn't
+    // affect the parent.
+    if (parentStillUnsafe && !unsafe.isForceSafe(context.channelId)) {
+      unsafe.setForceSafe(context.channelId);
+      return `✅ Thread overridden to safe mode for **${context.projectName}**. Parent channel is still in unsafe mode — run \`!safe\` there to revert it for the whole project.`;
+    }
+
+    return `**${context.projectName}** — already in safe mode.`;
   }
 
   if (cmd === '!help') {
@@ -304,15 +342,23 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
   const unsafeRegistry = createUnsafeRegistry();
 
   /**
-   * True when this reply target should be sent in unsafe (bypass) mode —
-   * either the channel/thread itself is enabled, or its parent project
-   * channel is enabled (so `!unsafe` in a project channel propagates to
-   * threads created inside it).
+   * True when this reply target should be sent in unsafe (bypass) mode.
+   *
+   * Resolution order (#238):
+   *  1. The channel/thread itself enabled? → unsafe.
+   *  2. The channel/thread explicitly force-safe? → safe (override beats inheritance).
+   *  3. Parent channel enabled (for threads)? → unsafe (inherited).
+   *  4. Otherwise → safe.
+   *
+   * The force-safe check sits between (1) and (3) so a thread operator can
+   * say "this thread should NOT inherit my parent's `!unsafe`" without
+   * having to disable the parent.
    */
   function isUnsafeReplyTarget(replyChannel: TextChannel | ThreadChannel): boolean {
     if (unsafeRegistry.isEnabled(replyChannel.id)) return true;
-    if (replyChannel.isThread() && replyChannel.parentId && unsafeRegistry.isEnabled(replyChannel.parentId)) {
-      return true;
+    if (replyChannel.isThread() && replyChannel.parentId) {
+      if (unsafeRegistry.isForceSafe(replyChannel.id)) return false;
+      if (unsafeRegistry.isEnabled(replyChannel.parentId)) return true;
     }
     return false;
   }
@@ -424,6 +470,7 @@ export function createDiscordBot(token: string, router: Router, sessionManager: 
         channelId: resolved.channelId,
         projectName: resolved.name,
         isThread: resolved.isThread,
+        parentChannelId: parentId,
       }, unsafeRegistry);
       if (response) {
         await message.channel.send(response);

--- a/src/unsafe-mode.ts
+++ b/src/unsafe-mode.ts
@@ -14,6 +14,13 @@
  * registry. Any other message — including a re-typed `!unsafe`, which
  * refreshes the window — clears or replaces the pending arm. This prevents a
  * single typo from granting bypass-permissions for the rest of the session.
+ *
+ * Force-safe (#238): a thread inherits its parent channel's unsafe state by
+ * default — useful when an operator wants `!unsafe` to apply to the whole
+ * project. The force-safe flag is the explicit opt-out: when set on a
+ * channel, that channel is treated as safe even if its parent is unsafe.
+ * `!safe` in a thread that's only inheriting from an unsafe parent sets
+ * this flag (rather than being a silent no-op as it was before #238).
  */
 
 /** Default confirmation window for `!unsafe` → `!unsafe confirm` (60 seconds). */
@@ -24,7 +31,11 @@ interface PendingArm {
 }
 
 export interface UnsafeRegistry {
-  /** Mark a channel/thread as unsafe-mode for the rest of the session. */
+  /**
+   * Mark a channel/thread as unsafe-mode for the rest of the session.
+   * Clears any force-safe override on the same channel as a side effect —
+   * the two flags are contradictory.
+   */
   enable(channelId: string): void;
   /** Revert a channel/thread to safe mode. No-op if not enabled. */
   disable(channelId: string): void;
@@ -56,6 +67,18 @@ export interface UnsafeRegistry {
    * entries are evicted as a side effect.
    */
   hasPendingArm(channelId: string): boolean;
+
+  /**
+   * Mark a channel as explicitly safe so it does NOT inherit unsafe mode
+   * from its parent. Only meaningful for threads (parent channels have no
+   * inheritance to override), but the flag is per-channel and could in
+   * principle be set on any id without harm.
+   */
+  setForceSafe(channelId: string): void;
+  /** Drop the force-safe override on a channel. No-op if not set. */
+  clearForceSafe(channelId: string): void;
+  /** Whether this channel has been explicitly opted out of inherited unsafe. */
+  isForceSafe(channelId: string): boolean;
 }
 
 export interface UnsafeRegistryOptions {
@@ -79,6 +102,7 @@ export function createUnsafeRegistry(opts?: UnsafeRegistryOptions): UnsafeRegist
   const now = opts?.now ?? (() => Date.now());
   const enabled = new Set<string>();
   const pending = new Map<string, PendingArm>();
+  const forceSafe = new Set<string>();
 
   function isFresh(armedAt: number): boolean {
     return now() - armedAt < windowMs;
@@ -87,6 +111,9 @@ export function createUnsafeRegistry(opts?: UnsafeRegistryOptions): UnsafeRegist
   return {
     enable(channelId) {
       enabled.add(channelId);
+      // Enabling a channel and force-safing it are contradictory; the
+      // explicit enable wins.
+      forceSafe.delete(channelId);
     },
     disable(channelId) {
       enabled.delete(channelId);
@@ -118,6 +145,16 @@ export function createUnsafeRegistry(opts?: UnsafeRegistryOptions): UnsafeRegist
         return false;
       }
       return true;
+    },
+
+    setForceSafe(channelId) {
+      forceSafe.add(channelId);
+    },
+    clearForceSafe(channelId) {
+      forceSafe.delete(channelId);
+    },
+    isForceSafe(channelId) {
+      return forceSafe.has(channelId);
     },
   };
 }

--- a/tests/discord.test.ts
+++ b/tests/discord.test.ts
@@ -445,6 +445,116 @@ describe('handleCommand', () => {
     expect(result).toContain('!safe');
   });
 
+  // --- !safe with parent-thread inheritance (#238) ---
+
+  it('!safe in a thread whose parent is unsafe sets force-safe (overrides inheritance) and acks parent state', () => {
+    const sm = mockSessionManager();
+    const unsafe = createUnsafeRegistry();
+    unsafe.enable('ch-1'); // parent project channel
+    const result = handleCommand('!safe', testConfig, sm, {
+      channelId: 'thread-99',
+      projectName: 'Alpha',
+      isThread: true,
+      parentChannelId: 'ch-1',
+    }, unsafe);
+    expect(result).toMatch(/thread overridden to safe/i);
+    expect(result).toMatch(/parent channel is still in unsafe/i);
+    expect(unsafe.isForceSafe('thread-99')).toBe(true);
+    // Parent itself remains unsafe — this thread did NOT disable the parent.
+    expect(unsafe.isEnabled('ch-1')).toBe(true);
+    // Thread itself was never enabled, so disable() was not called there either.
+    expect(unsafe.isEnabled('thread-99')).toBe(false);
+  });
+
+  it('!safe in a thread when neither thread nor parent is unsafe still reports already-safe', () => {
+    const sm = mockSessionManager();
+    const unsafe = createUnsafeRegistry();
+    const result = handleCommand('!safe', testConfig, sm, {
+      channelId: 'thread-99',
+      projectName: 'Alpha',
+      isThread: true,
+      parentChannelId: 'ch-1',
+    }, unsafe);
+    expect(result).toMatch(/already in safe mode/i);
+    expect(unsafe.isForceSafe('thread-99')).toBe(false);
+  });
+
+  it('!safe in a thread that is itself unsafe (parent NOT enabled) disables the thread without touching force-safe', () => {
+    const sm = mockSessionManager();
+    const unsafe = createUnsafeRegistry();
+    unsafe.enable('thread-99');
+    const result = handleCommand('!safe', testConfig, sm, {
+      channelId: 'thread-99',
+      projectName: 'Alpha',
+      isThread: true,
+      parentChannelId: 'ch-1',
+    }, unsafe);
+    expect(result).toMatch(/safe mode restored/i);
+    expect(unsafe.isEnabled('thread-99')).toBe(false);
+    expect(unsafe.isForceSafe('thread-99')).toBe(false);
+  });
+
+  it('!safe in a thread that is itself unsafe AND has an unsafe parent also force-safes (covers PR #241 review edge case)', () => {
+    const sm = mockSessionManager();
+    const unsafe = createUnsafeRegistry();
+    unsafe.enable('ch-1');       // parent enabled
+    unsafe.enable('thread-99');  // thread also enabled (force-safe was cleared by enable())
+    const result = handleCommand('!safe', testConfig, sm, {
+      channelId: 'thread-99',
+      projectName: 'Alpha',
+      isThread: true,
+      parentChannelId: 'ch-1',
+    }, unsafe);
+    // Without the edge-case branch, plain disable() would leave the thread
+    // inheriting unsafe from the still-enabled parent — exactly the bug
+    // class this PR was meant to close.
+    expect(result).toMatch(/thread disabled and overridden to safe/i);
+    expect(result).toMatch(/parent channel is still in unsafe/i);
+    expect(unsafe.isEnabled('thread-99')).toBe(false);
+    expect(unsafe.isForceSafe('thread-99')).toBe(true);
+    expect(unsafe.isEnabled('ch-1')).toBe(true);
+  });
+
+  it('!safe twice in a thread under unsafe parent does not re-arm force-safe', () => {
+    const sm = mockSessionManager();
+    const unsafe = createUnsafeRegistry();
+    unsafe.enable('ch-1');
+    handleCommand('!safe', testConfig, sm, {
+      channelId: 'thread-99', projectName: 'Alpha', isThread: true, parentChannelId: 'ch-1',
+    }, unsafe);
+    const second = handleCommand('!safe', testConfig, sm, {
+      channelId: 'thread-99', projectName: 'Alpha', isThread: true, parentChannelId: 'ch-1',
+    }, unsafe);
+    // Second call should treat the thread as already-safe (force-safe is set), not "override again".
+    expect(second).toMatch(/already in safe mode/i);
+    expect(unsafe.isForceSafe('thread-99')).toBe(true);
+  });
+
+  it('!unsafe + !unsafe confirm in a thread that was force-safe re-enables the thread and clears force-safe', () => {
+    const sm = mockSessionManager();
+    const unsafe = createUnsafeRegistry();
+    unsafe.enable('ch-1');
+    unsafe.setForceSafe('thread-99');
+    // Arm via !unsafe — does not enable on its own (#239).
+    handleCommand('!unsafe', testConfig, sm, {
+      channelId: 'thread-99',
+      projectName: 'Alpha',
+      isThread: true,
+      parentChannelId: 'ch-1',
+    }, unsafe);
+    expect(unsafe.isEnabled('thread-99')).toBe(false);
+    expect(unsafe.isForceSafe('thread-99')).toBe(true); // arm alone doesn't clear force-safe
+    // Confirm: enable() now fires, which clears force-safe as a side effect.
+    handleCommand('!unsafe confirm', testConfig, sm, {
+      channelId: 'thread-99',
+      projectName: 'Alpha',
+      isThread: true,
+      parentChannelId: 'ch-1',
+    }, unsafe);
+    expect(unsafe.isEnabled('thread-99')).toBe(true);
+    expect(unsafe.isForceSafe('thread-99')).toBe(false);
+  });
+
 });
 
 describe('agent handoff flow', () => {

--- a/tests/unsafe-mode.test.ts
+++ b/tests/unsafe-mode.test.ts
@@ -154,3 +154,70 @@ describe('createUnsafeRegistry — pending arm / confirmation flow (#239)', () =
     expect(reg.hasPendingArm('chan-1')).toBe(true); // unaffected
   });
 });
+
+describe('createUnsafeRegistry — force-safe override (#238)', () => {
+  it('starts with no force-safe channels', () => {
+    const reg = createUnsafeRegistry();
+    expect(reg.isForceSafe('thread-1')).toBe(false);
+  });
+
+  it('setForceSafe marks a channel as explicitly safe', () => {
+    const reg = createUnsafeRegistry();
+    reg.setForceSafe('thread-1');
+    expect(reg.isForceSafe('thread-1')).toBe(true);
+  });
+
+  it('clearForceSafe drops the override', () => {
+    const reg = createUnsafeRegistry();
+    reg.setForceSafe('thread-1');
+    reg.clearForceSafe('thread-1');
+    expect(reg.isForceSafe('thread-1')).toBe(false);
+  });
+
+  it('clearForceSafe is a no-op when not set', () => {
+    const reg = createUnsafeRegistry();
+    expect(() => reg.clearForceSafe('thread-1')).not.toThrow();
+    expect(reg.isForceSafe('thread-1')).toBe(false);
+  });
+
+  it('force-safe is independent of enabled — both can coexist on different channels', () => {
+    const reg = createUnsafeRegistry();
+    reg.enable('parent-1');
+    reg.setForceSafe('thread-1');
+    expect(reg.isEnabled('parent-1')).toBe(true);
+    expect(reg.isForceSafe('thread-1')).toBe(true);
+    // No cross-contamination
+    expect(reg.isEnabled('thread-1')).toBe(false);
+    expect(reg.isForceSafe('parent-1')).toBe(false);
+  });
+
+  it('enable() clears any force-safe on the same channel (contradictory states resolve to enabled)', () => {
+    const reg = createUnsafeRegistry();
+    reg.setForceSafe('thread-1');
+    reg.enable('thread-1');
+    expect(reg.isEnabled('thread-1')).toBe(true);
+    expect(reg.isForceSafe('thread-1')).toBe(false);
+  });
+
+  it('disable() does NOT clear force-safe — operator intent persists', () => {
+    const reg = createUnsafeRegistry();
+    reg.enable('thread-1');     // also clears any force-safe
+    reg.setForceSafe('thread-1');
+    reg.disable('thread-1');
+    expect(reg.isEnabled('thread-1')).toBe(false);
+    expect(reg.isForceSafe('thread-1')).toBe(true);
+  });
+
+  it('force-safe channels are not included in list() (which only tracks enabled)', () => {
+    const reg = createUnsafeRegistry();
+    reg.setForceSafe('thread-1');
+    expect(reg.list()).toEqual([]);
+  });
+
+  it('force-safe channels are isolated from each other', () => {
+    const reg = createUnsafeRegistry();
+    reg.setForceSafe('thread-1');
+    expect(reg.isForceSafe('thread-1')).toBe(true);
+    expect(reg.isForceSafe('thread-2')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #238.

Before: `isUnsafeReplyTarget` treated a thread as unsafe whenever the thread itself **or** its parent was enabled. `!safe` inside a thread that was only inheriting from an unsafe parent was a silent no-op — `disable()` on the thread's id couldn't affect the parent, and the ack misleadingly said *"already in safe mode"* even though the next prompt would still spawn under `bypassPermissions`.

After: a per-channel **force-safe** override on `UnsafeRegistry` wins against parent inheritance. `!safe` in a thread that's only inheriting now sets the override (instead of being a no-op) and acks with the parent's actual state. Resolution order in `isUnsafeReplyTarget` is:

1. Thread/channel itself enabled? → unsafe.
2. Channel force-safed? → safe (override beats inheritance).
3. Parent enabled (for threads)? → unsafe (inherited).
4. Otherwise → safe.

## Changes

- `src/unsafe-mode.ts` — `UnsafeRegistry` gains `setForceSafe` / `clearForceSafe` / `isForceSafe`. `enable()` clears force-safe as a side effect (contradictory states resolve to enabled). `disable()` deliberately does NOT clear force-safe so an operator's intent persists if the parent later toggles.
- `src/discord.ts` —
  - `isUnsafeReplyTarget` consults the override before falling back to parent inheritance.
  - `CommandContext` gains a `parentChannelId?: string` field; the `MessageCreate` handler passes the resolved parent.
  - `!safe` branch detects "thread inheriting unsafe from unsafe parent" and sets force-safe rather than reporting already-safe.
- Docs (README security model + commands table, `docs/ARCHITECTURE.md` escalation row) describe the new behavior.

## Test plan

- [x] `npm test` — **720/720 passing** (706 master + 14 new):
  - `UnsafeRegistry` force-safe: basics, channel isolation, exclusion from `list()`, `enable()` clearing, `disable()` preserving.
  - `handleCommand !safe`: thread under unsafe parent sets force-safe and doesn't touch the parent; both-safe still reports already-safe; thread itself unsafe disables (existing behavior preserved); double-`!safe` is idempotent; `!unsafe` in a force-safed thread re-enables and clears the override.
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [ ] Manual smoke: `!unsafe` in a project channel, `!safe` inside a child thread, send a prompt in the thread → spawns under curated allowlist (not bypass); send a prompt in the parent or a sibling thread → still bypass.

## Coordination with PR #240

Branched off `master` at `e4ac4a7`. PR #240 (`feat: gate commands behind allowedRoles + require confirm for !unsafe (#237, #239)`) is in flight on the same files (`handleCommand` `!safe`, `UnsafeRegistry`). Whichever merges first, the other will need a small rebase to reconcile the `!safe` branch — the two changes are orthogonal in intent (#240 adds pending-arm clearing, #238 adds force-safe override) and the merge should be straightforward.

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)