### PR TITLE
refactor(ayumi): use ayumi's topicVaultPath in curator-commands (closes #244)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1491,7 +1491,7 @@
     },
     "node_modules/ayumi": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/yama-kei/ayumi.git#9d619637392068cb4136b9a8221c333910c2e6a6",
+      "resolved": "git+ssh://git@github.com/yama-kei/ayumi.git#f89bc268658e45ea859555ca5bcb3886019a1e74",
       "optional": true,
       "dependencies": {
         "robots-parser": "^3.0.1",

--- a/src/ayumi/curator-commands.ts
+++ b/src/ayumi/curator-commands.ts
@@ -13,6 +13,7 @@
 import type { BrokerClient } from '../broker-client.js';
 import { createBrokerClientFromEnv } from '../broker-client.js';
 import type { Topic } from 'ayumi';
+import { topicVaultPath } from 'ayumi';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
@@ -37,17 +38,9 @@ interface FolderMap {
 }
 
 const TOPIC_FOLDERS: readonly Topic[] = ['work', 'travel', 'finance', 'health', 'social', 'hobbies'];
-const SENSITIVE_TOPICS: Topic[] = ['finance', 'health'];
 const MANIFEST_NAME = 'pending-review.json';
 
 // ---- Vault helpers (previously in vault-writer.ts) ----
-
-function topicDir(vaultPath: string, topic: Topic): string {
-  if (SENSITIVE_TOPICS.includes(topic)) {
-    return join(vaultPath, 'topics', '_sensitive', topic);
-  }
-  return join(vaultPath, 'topics', topic);
-}
 
 function generateFrontmatter(opts: {
   tier: 1 | 2 | 3;
@@ -288,7 +281,7 @@ async function handleVaultApprove(vaultPath: string, arg: string): Promise<strin
 
     const entry = manifest.topics[topic];
     const topicName = topic as Topic;
-    const dir = topicDir(vaultPath, topicName);
+    const dir = topicVaultPath(vaultPath, topicName);
 
     // Write the approved summary.md to vault with frontmatter
     await mkdir(dir, { recursive: true });


### PR DESCRIPTION
## Summary
- Replaces the local `SENSITIVE_TOPICS` const and `topicDir` helper in `src/ayumi/curator-commands.ts` with `topicVaultPath` imported from the `ayumi` package — the two implementations were byte-for-byte equivalent.
- Bumps the `ayumi` dep resolution from `9d619637` to `f89bc26` (the merge of [yama-kei/ayumi#100](https://github.com/yama-kei/ayumi/pull/100), which added `topicVaultPath` to ayumi's root barrel).
- Closes the residual fragment of the Phase 2a extraction; mpg now has zero local copies of life-context topic-routing logic.

Closes #244. Follow-up to #243 and [yama-kei/ayumi#80](https://github.com/yama-kei/ayumi/issues/80).

## Test plan
- [x] `grep -rn "SENSITIVE_TOPICS\|topicVaultPath" src/` shows only the import line and the single call site — no local definitions
- [x] `npm test` — 996/996 passing
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` (tsup) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)